### PR TITLE
[Issue 124] Purchase Order Workflow: Add email task to end of purchase order workflow.

### DIFF
--- a/purchase-orders/nodes/buildSuccessEmail.json
+++ b/purchase-orders/nodes/buildSuccessEmail.json
@@ -1,0 +1,8 @@
+{
+  "id": "a17feeb4-2376-430d-97e6-21ce0a1e1719",
+  "name": "Build Success E-mail",
+  "description": "",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "buildSuccessEmail.js"
+}

--- a/purchase-orders/nodes/deleteMarcInputFile.json
+++ b/purchase-orders/nodes/deleteMarcInputFile.json
@@ -3,9 +3,14 @@
   "name": "Delete MARC input file",
   "description": "",
   "deserializeAs": "FileTask",
-  "inputVariables": [],
+  "inputVariables": [
+    {
+      "key": "inputFilePath",
+      "type": "PROCESS"
+    }
+  ],
   "outputVariable": {},
-  "path": "/mnt/po.mrc",
+  "path": "${inputFilePath}",
   "op": "DELETE",
   "asyncBefore": true
 }

--- a/purchase-orders/nodes/js/buildSuccessEmail.js
+++ b/purchase-orders/nodes/js/buildSuccessEmail.js
@@ -1,0 +1,43 @@
+var reportObj = JSON.parse(report);
+
+var fileName = inputFilePath.replace(/.*\/([^\/]+)$/i, '$1');
+var successEmailSubject = 'Purchase Orders Workflow Result for ' + fileName;
+var successEmailMarkup = '<p>A total of <strong>' + reportObj.records.length + '</strong> records from <strong>' + fileName + '</strong> were successfully processed.</p>';
+var successEmailText = '';
+
+successEmailMarkup += '<p>';
+for (var i = 0; i < reportObj.records.length; ++i) {
+  successEmailMarkup += '<p>Purchase Order Number: ' + reportObj.records[i].poNumber + '</p>';
+  successEmailMarkup += '<ul>';
+  successEmailMarkup += '<li>\tInstance UUID: ' + reportObj.records[i].instanceUuid + '</li>';
+  successEmailMarkup += '<li>\tInstance HRID: ' + reportObj.records[i].instanceHrid + '</li>';
+  successEmailMarkup += '</ul>';
+}
+successEmailMarkup += '</p>';
+
+successEmailText = successEmailMarkup.replace(/<\/p>/ig, '\n')
+  .replace(/<\/li>/ig, '\n')
+  .replace(/<\/ul>/ig, '\n')
+  .replace(/<\/[^>]+>/ig, '')
+  .replace(/<[^>]+>/ig, '');
+
+successEmailMarkup = successEmailMarkup.replace(/\t/ig, '');
+
+if (logLevel === 'INFO' || logLevel === 'DEBUG') {
+  print('inputFilePath = ' + inputFilePath);
+  print('fileName = ' + fileName);
+  print('emailTo = ' + emailTo);
+  print('emailFrom = ' + emailFrom);
+  print('totalRecords = ' + reportObj.records.length + '\n');
+
+  if (logLevel === 'DEBUG') {
+    print('successEmailSubject = ' + successEmailSubject);
+    print('successEmailText = ' + successEmailText);
+    print('successEmailMarkup = ' + successEmailMarkup);
+    print('reportObj = ' + reportObj + '\n');
+  }
+}
+
+execution.setVariableLocal('successEmailSubject', successEmailSubject);
+execution.setVariableLocal('successEmailText', successEmailText);
+execution.setVariableLocal('successEmailMarkup', successEmailMarkup);

--- a/purchase-orders/nodes/js/buildSuccessEmail.js
+++ b/purchase-orders/nodes/js/buildSuccessEmail.js
@@ -2,7 +2,7 @@ var reportObj = JSON.parse(report);
 
 var fileName = inputFilePath.replace(/.*\/([^\/]+)$/i, '$1');
 var successEmailSubject = 'Purchase Orders Workflow Result for ' + fileName;
-var successEmailMarkup = '<p>A total of <strong>' + reportObj.records.length + '</strong> records from <strong>' + fileName + '</strong> were successfully processed.</p>';
+var successEmailMarkup = '<p>A total of <strong>' + reportObj.records.length + '</strong> records from <strong>' + fileName + '</strong> were successfully processed.</p>\n';
 var successEmailText = '';
 
 successEmailMarkup += '<p>';
@@ -21,7 +21,8 @@ successEmailText = successEmailMarkup.replace(/<\/p>/ig, '\n')
   .replace(/<\/[^>]+>/ig, '')
   .replace(/<[^>]+>/ig, '');
 
-successEmailMarkup = successEmailMarkup.replace(/\t/ig, '');
+successEmailMarkup = successEmailMarkup.replace(/\t/ig, '')
+  .replace(/\n/ig, '');
 
 if (logLevel === 'INFO' || logLevel === 'DEBUG') {
   print('inputFilePath = ' + inputFilePath);

--- a/purchase-orders/nodes/js/extractFieldsFromMarcRecord.js
+++ b/purchase-orders/nodes/js/extractFieldsFromMarcRecord.js
@@ -27,7 +27,7 @@ var getMultipleSubfield = function (fields, tag, code) {
           data.push(fields[i].subfields[j].data);
         }
       }
-      break
+      break;
     }
   }
   return data;

--- a/purchase-orders/nodes/js/logger.js
+++ b/purchase-orders/nodes/js/logger.js
@@ -29,7 +29,7 @@ if (logLevel === 'DEBUG') {
   print('\nmarcOrderData = ' + marcOrderData + '\n');
 
   print('\ncompositePurchaseOrder = ' + compositePurchaseOrder + '\n');
-  
+
   print('\njobExecution = ' + jobExecution + '\n');
   print('\nsourceRecord = ' + sourceRecord + '\n');
 

--- a/purchase-orders/nodes/js/postProcessRecord.js
+++ b/purchase-orders/nodes/js/postProcessRecord.js
@@ -1,0 +1,10 @@
+var reportObj = JSON.parse(report);
+var instanceObj = JSON.parse(instance);
+
+reportObj.records.push({
+  poNumber: JSON.parse(poNumberResponse).poNumber,
+  instanceUuid: instanceObj.id,
+  instanceHrid: instanceObj.hrid
+});
+
+execution.setVariable('report', S(JSON.stringify(reportObj)));

--- a/purchase-orders/nodes/js/splitMarcRecords.js
+++ b/purchase-orders/nodes/js/splitMarcRecords.js
@@ -3,4 +3,9 @@ var MarcUtility = Java.type("org.folio.rest.utility.MarcUtility");
 
 var records = MarcUtility.splitRawMarcToMarcJsonRecords(marc);
 
+var reportObj = {
+  records: []
+};
+
 execution.setVariableLocal('records', Variables.objectValue(records, true).create());
+execution.setVariable('report', S(JSON.stringify(reportObj)));

--- a/purchase-orders/nodes/postProcessRecord.json
+++ b/purchase-orders/nodes/postProcessRecord.json
@@ -1,0 +1,8 @@
+{
+  "id": "cdc9dab0-8182-4d5a-a494-51d7d8632fec",
+  "name": "Post-Process Record",
+  "description": "",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "postProcessRecord.js"
+}

--- a/purchase-orders/nodes/purchaseOrderSubprocess.json
+++ b/purchase-orders/nodes/purchaseOrderSubprocess.json
@@ -27,6 +27,7 @@
     "{{mod-workflow}}/moveToNode/c6fd79b2-d6d4-41fc-a2a4-db9848532600",
     "{{mod-workflow}}/scriptTask/dbd8367c-6859-4035-a67b-610377cd1680",
     "{{mod-workflow}}/subprocess/25e32f01-0d24-4e0a-8ed4-97dd59caada9",
+    "{{mod-workflow}}/scriptTask/cdc9dab0-8182-4d5a-a494-51d7d8632fec",
     "{{mod-workflow}}/scriptTask/98606522-0f5a-4950-952f-d3e3fac86832",
     "{{mod-workflow}}/endEvent/ab94addf-021b-4b86-a49a-c370a3b3e9dc"
   ],

--- a/purchase-orders/nodes/readMarcInputFile.json
+++ b/purchase-orders/nodes/readMarcInputFile.json
@@ -3,13 +3,18 @@
   "name": "Read MARC input file",
   "description": "",
   "deserializeAs": "FileTask",
-  "inputVariables": [],
+  "inputVariables": [
+    {
+      "key": "inputFilePath",
+      "type": "PROCESS"
+    }
+  ],
   "outputVariable": {
     "key": "marc",
     "type": "PROCESS",
     "asTransient": true
   },
-  "path": "/mnt/po.mrc",
+  "path": "${inputFilePath}",
   "op": "READ",
   "asyncBefore": true
 }

--- a/purchase-orders/nodes/sendSuccessEmail.json
+++ b/purchase-orders/nodes/sendSuccessEmail.json
@@ -1,0 +1,35 @@
+{
+  "id": "3dd5d171-771c-48a7-a2e7-9d063190c3e5",
+  "name": "Send Success Email",
+  "description": "",
+  "deserializeAs": "EmailTask",
+  "inputVariables": [
+    {
+      "key": "emailTo",
+      "type": "PROCESS"
+    },
+    {
+      "key": "emailFrom",
+      "type": "PROCESS"
+    },
+    {
+      "key": "successEmailSubject",
+      "type": "LOCAL"
+    },
+    {
+      "key": "successEmailText",
+      "type": "LOCAL"
+    },
+    {
+      "key": "successEmailMarkup",
+      "type": "LOCAL"
+    }
+  ],
+  "outputVariable": {},
+  "mailTo": "${emailTo}",
+  "mailFrom": "${emailFrom}",
+  "mailSubject": "${successEmailSubject}",
+  "mailText": "${successEmailText}",
+  "mailMarkup": "${successEmailMarkup}",
+  "asyncBefore": true
+}

--- a/purchase-orders/workflow.json
+++ b/purchase-orders/workflow.json
@@ -22,6 +22,8 @@
     "{{mod-workflow}}/fileTask/08233df1-02cb-4608-874e-8c83b8f9e76a",
     "{{mod-workflow}}/scriptTask/ba6e0cdf-7c82-4ff1-9cc5-ea2570f334bc",
     "{{mod-workflow}}/subprocess/38f20fef-1dc1-4bce-9616-a47e33df5ba5",
+    "{{mod-workflow}}/scriptTask/a17feeb4-2376-430d-97e6-21ce0a1e1719",
+    "{{mod-workflow}}/emailTask/3dd5d171-771c-48a7-a2e7-9d063190c3e5",
     "{{mod-workflow}}/fileTask/eda78d56-b57f-4395-a374-5d7f9a9d03da",
     "{{mod-workflow}}/endEvent/98760d21-7f01-41d8-b915-39df79cad824"
   ],


### PR DESCRIPTION
Append to the workflow building and sending e-mail tasks.

Utilize dynamic and configurable file path.
The `path` json property no longer expects the path to the file and now expects the path to the directory containing the file.

The e-mail task is setting the text as HTML markup, but this does not work well with plain text (specifically the newlines).
Such an e-mail is not easily readable.
Change the behavior to send both plain text and HTML markup in a backwards compatible manner.
This introduces a new field called `markup`/`mailMarkup` that exists optionally in addition to the field `text`/`mailText`.

resolves #124 