### PR TITLE
Fetch acquisition methods as reference data to build composite purchase order

### DIFF
--- a/purchase-orders/nodes/acquisitionMethods.json
+++ b/purchase-orders/nodes/acquisitionMethods.json
@@ -1,0 +1,19 @@
+{
+  "id": "26586e32-7a3f-4b43-9128-b59e8c57846b",
+  "name": "Request Acquisition Methods",
+  "description": "Retrieve the acquisition methods.",
+  "deserializeAs": "RequestTask",
+  "request": {
+    "url": "{{okapi-internal}}/orders/acquisition-methods?limit=999",
+    "method": "GET",
+    "accept": "application/json"
+  },
+  "inputVariables": [],
+  "headerOutputVariables": [],
+  "outputVariable": {
+    "key": "acquisitionMethodsResponse",
+    "type": "PROCESS",
+    "spin": true
+  },
+  "asyncBefore": true
+}

--- a/purchase-orders/nodes/acquisitionMethodsConnectTo.json
+++ b/purchase-orders/nodes/acquisitionMethodsConnectTo.json
@@ -1,0 +1,7 @@
+{
+  "id": "925e098a-b353-40bb-8d94-c2c96515c978",
+  "name": "Complete Acquisition Methods",
+  "description": "",
+  "deserializeAs": "ConnectTo",
+  "nodeId": "parallel_gateway_9ee4d11c_ea5b_4080_9958_e0d964fd8447"
+}

--- a/purchase-orders/nodes/acquisitionMethodsMoveToNode.json
+++ b/purchase-orders/nodes/acquisitionMethodsMoveToNode.json
@@ -1,0 +1,11 @@
+{
+  "id": "989d0a8b-df95-4437-b4cf-f4211178b7ae",
+  "name": "Acquisition Methods",
+  "description": "",
+  "deserializeAs": "MoveToNode",
+  "gatewayId": "parallel_gateway_b4440bc5_6fe8_4bf3_aa41_57debe0a813f",
+  "nodes": [
+    "{{mod-workflow}}/requestTask/26586e32-7a3f-4b43-9128-b59e8c57846b",
+    "{{mod-workflow}}/connectTo/925e098a-b353-40bb-8d94-c2c96515c978"
+  ]
+}

--- a/purchase-orders/nodes/js/buildCompositePurchaseOrder.js
+++ b/purchase-orders/nodes/js/buildCompositePurchaseOrder.js
@@ -9,6 +9,7 @@ if (logLevel === 'DEBUG') {
   print('\nfundsResponse = ' + fundsResponse + '\n');
   print('\nexpenseClassesResponse = ' + expenseClassesResponse + '\n');
   print('\nmaterialTypesResponse = ' + materialTypesResponse + '\n');
+  print('\nacquisitionMethodsResponse = ' + acquisitionMethodsResponse + '\n');
 }
 
 var poNumber = JSON.parse(poNumberResponse).poNumber;
@@ -25,9 +26,35 @@ var locations = JSON.parse(locationsResponse).locations;
 
 var materialTypes = JSON.parse(materialTypesResponse).mtypes;
 
+var materialTypes = JSON.parse(materialTypesResponse).mtypes;
+
+var acquisitionMethods = JSON.parse(acquisitionMethodsResponse).acquisitionMethods;
+
 var marcOrderDataObj = JSON.parse(marcOrderData);
 
 var electronic = marcOrderDataObj.electronicIndicator && marcOrderDataObj.electronicIndicator.toLowerCase().indexOf('electronic') >= 0;
+
+var findLocationIdByName = function (locationName) {
+  for (var i = 0; i < locations.length; ++i) {
+    if (locationName === locations[i].name) return locations[i].id;
+  }
+};
+
+var findMaterialTypeIdByName = function (materialTypeName) {
+  for (var i = 0; i < materialTypes.length; ++i) {
+    if (materialTypeName === materialTypes[i].name) return materialTypes[i].id;
+  }
+};
+
+var findAcquisitionMethodByValue = function (acquisitionMethodValue) {
+  for (var i = 0; i < acquisitionMethods.length; ++i) {
+    if (acquisitionMethodValue === acquisitionMethods[i].value) return acquisitionMethods[i].id;
+  }
+};
+
+var acquisitionMethod = findAcquisitionMethodByValue(marcOrderDataObj.acquisitionMethod);
+
+print('\nacquisitionMethodFromMARC = ' + marcOrderDataObj.acquisitionMethod + ' (' + acquisitionMethod + ')\n');
 
 var orderLine = {
   id: orderLineId,
@@ -49,7 +76,7 @@ var orderLine = {
   description: marcOrderDataObj.internalNote,
   selector: marcOrderDataObj.selector,
   requester: marcOrderDataObj.requester,
-  acquisitionMethod: marcOrderDataObj.acquisitionMethod
+  acquisitionMethod: acquisitionMethod
 };
 
 var compositePoLines = [
@@ -70,17 +97,7 @@ var compositePurchaseOrder = {
 
 var tagList = [];
 
-var findLocationIdByName = function (locationName) {
-  for (var i = 0; i < locations.length; ++i) {
-    if (locationName === locations[i].name) return locations[i].id;
-  }
-};
 
-var findMaterialTypeIdByName = function (materialTypeName) {
-  for (var i = 0; i < materialTypes.length; ++i) {
-    if (materialTypeName === materialTypes[i].name) return materialTypes[i].id;
-  }
-};
 
 if (electronic) {
   orderLine.orderFormat = 'Electronic Resource';

--- a/purchase-orders/nodes/js/prepareHoldings.js
+++ b/purchase-orders/nodes/js/prepareHoldings.js
@@ -2,6 +2,7 @@ var instanceObj = JSON.parse(instance);
 
 if (logLevel === 'DEBUG') {
   print('\nholdingsResponse = ' + holdingsResponse + '\n');
+  print('\nholdingsType = ' + holdingsType + '\n');
 }
 
 var holdingsObj = JSON.parse(holdingsResponse).holdingsRecords[0];
@@ -49,6 +50,8 @@ holdingsObj.callNumberTypeId = callNumberTypeId;
 holdingsObj.statisticalCodeIds = mapStatisticalCodeIds(statisticalCodes);
 
 holdingsObj.discoverySuppress = false;
+
+holdingsObj._version = 1;
 
 if (logLevel === 'DEBUG') {
   print('\nholdings = ' + JSON.stringify(holdingsObj) + '\n');

--- a/purchase-orders/nodes/js/prepareInstance.js
+++ b/purchase-orders/nodes/js/prepareInstance.js
@@ -34,9 +34,10 @@ mappedInstanceObj.discoverySuppress = false;
 
 mappedInstanceObj.statisticalCodeIds = mapStatisticalCodeIds(statisticalCodes);
 
+mappedInstanceObj._version = 1;
+
 if (logLevel === 'DEBUG') {
   print('\ninstance = ' + JSON.stringify(mappedInstanceObj) + '\n');
 }
 
 execution.setVariable('instance', S(JSON.stringify(mappedInstanceObj)));
-

--- a/purchase-orders/nodes/requestAcquisitionMethodsForPurchaseOrderLineFork.json
+++ b/purchase-orders/nodes/requestAcquisitionMethodsForPurchaseOrderLineFork.json
@@ -1,0 +1,10 @@
+{
+  "id": "9f90e981-553d-4b27-a34a-47f56611c49e",
+  "name": "Request Acquisition Methods For Purchase Order Line Fork",
+  "description": "",
+  "deserializeAs": "ParallelGateway",
+  "nodes": [
+    "{{mod-workflow}}/requestTask/26586e32-7a3f-4b43-9128-b59e8c57846b",
+    "{{mod-workflow}}/parallelGateway/372aad6f-1fd7-447e-ab43-9c1c1ae9623f"
+  ]
+}

--- a/purchase-orders/nodes/requestAcquisitionMethodsForPurchaseOrderLineJoin.json
+++ b/purchase-orders/nodes/requestAcquisitionMethodsForPurchaseOrderLineJoin.json
@@ -1,0 +1,7 @@
+{
+  "id": "372aad6f-1fd7-447e-ab43-9c1c1ae9623f",
+  "name": "Request Acquisition Methods For Purchase Order Line Join",
+  "description": "",
+  "deserializeAs": "ParallelGateway",
+  "nodes": []
+}

--- a/purchase-orders/workflow.json
+++ b/purchase-orders/workflow.json
@@ -19,6 +19,7 @@
     "{{mod-workflow}}/moveToNode/12f41362-f0ed-4197-9fe3-9241cecba4c0",
     "{{mod-workflow}}/moveToNode/fc0a73ac-031c-4c48-a108-c78886ca9ff6",
     "{{mod-workflow}}/moveToNode/8df18451-8401-46f2-a4ff-ce14501a1073",
+    "{{mod-workflow}}/moveToNode/989d0a8b-df95-4437-b4cf-f4211178b7ae",
     "{{mod-workflow}}/fileTask/08233df1-02cb-4608-874e-8c83b8f9e76a",
     "{{mod-workflow}}/scriptTask/ba6e0cdf-7c82-4ff1-9cc5-ea2570f334bc",
     "{{mod-workflow}}/subprocess/38f20fef-1dc1-4bce-9616-a47e33df5ba5",


### PR DESCRIPTION
Add acquisition method lookup in pre subprocess parallel gateway during reference data lookup. Lookup can occur asynchronously as well as subprocess. We can take a pass on workflows to ensure all compatible with parallel subprocessing.