### PR TITLE
Coral extract duplicate instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ CONSTRAINT coral_extract_pkey PRIMARY KEY (coralid)
 
 CREATE TABLE mis.coral_instances (
 coralid int2 NOT NULL,
-instance_id varchar(36) NULL,
+instanceid varchar(36) NULL,
 CONSTRAINT coral_instances_pkey PRIMARY KEY (coralid)
 );
 ```

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ fw activate rapid-electronic-serials
 
 Extract Coral Data and Import it into Folio (Scheduled).
 
-This utilizes LDP, which must have the table `mis.coral_extract` manually created.
+This utilizes LDP, which must have tables `mis.coral_extract` and `mis.coral_instances` manually created.
 Each execution of this workflow clears the LDP table `mis.coral_extract` near the start of the process.
 
 ```sql
@@ -213,6 +213,12 @@ natureofcontentterm varchar(200) NULL,
 electronicaccess varchar(2000) NULL,
 status varchar(8) NULL,
 CONSTRAINT coral_extract_pkey PRIMARY KEY (coralid)
+);
+
+CREATE TABLE mis.coral_instances (
+coralid int2 NOT NULL,
+instance_id varchar(36) NULL,
+CONSTRAINT coral_instances_pkey PRIMARY KEY (coralid)
 );
 ```
 

--- a/coral-extract/nodes/coralItemsSubprocess.json
+++ b/coral-extract/nodes/coralItemsSubprocess.json
@@ -8,6 +8,7 @@
     "{{mod-workflow}}/startEvent/984e9bd7-da9f-4d9e-ac3c-4cdf0b7e5fd2",
     "{{mod-workflow}}/scriptTask/a20f3e19-9e0d-451d-af57-171f4fc05b66",
     "{{mod-workflow}}/requestTask/f84bb551-2aa2-4e0c-ac5b-03f302013817",
+    "{{mod-workflow}}/databaseQueryTask/b32e9dcc-992a-471e-8f76-769c215d3060",
     "{{mod-workflow}}/scriptTask/478d4468-289e-48c1-90ca-6a09bcbc252b",
     "{{mod-workflow}}/requestTask/b4887237-d835-4712-a645-7fae45062fcc",
     "{{mod-workflow}}/endEvent/0956649b-0717-4ea6-802a-45c15e62ad73"

--- a/coral-extract/nodes/js/prepareInstanceQuery.js
+++ b/coral-extract/nodes/js/prepareInstanceQuery.js
@@ -1,5 +1,0 @@
-var FormatUtility = Java.type('org.folio.rest.utility.FormatUtility');
-var item = JSON.parse(coralItem);
-var cqlTitle = FormatUtility.normalizeCqlUrlArgument(item.title);
-
-execution.setVariableLocal('instanceQuery', 'title==' + cqlTitle);

--- a/coral-extract/nodes/readFromLdp.json
+++ b/coral-extract/nodes/readFromLdp.json
@@ -10,6 +10,6 @@
     "spin": true
   },
   "designation": "ldp",
-  "query": "SELECT c.* FROM mis.coral_extract c WHERE status = 'ACTIVE' AND natureOfContentTerm IN ('Database', 'Dataset', 'Proceedings', 'Tool', 'Website') AND title IS NOT NULL AND electronicAccess IS NOT NULL AND coralId IN (SELECT coralid FROM mis.coral_extract EXCEPT SELECT cast(substring(uri, position('resource=' IN uri)+9) AS integer) FROM folio_reporting.instance_electronic_access WHERE uri LIKE '%coral.library.tamu.edu/resourcelink.php?resource=%')",
+  "query": "SELECT c.* FROM mis.coral_extract c WHERE status = 'ACTIVE' AND natureOfContentTerm IN ('Database', 'Dataset', 'Proceedings', 'Tool', 'Website') AND title IS NOT NULL AND electronicAccess IS NOT NULL AND coralId IN (SELECT coralid FROM mis.coral_extract EXCEPT SELECT coralid FROM mis.coral_instances)",
   "asyncBefore": true
 }

--- a/coral-extract/nodes/saveCreatedInstanceToLDP.json
+++ b/coral-extract/nodes/saveCreatedInstanceToLDP.json
@@ -17,6 +17,6 @@
   ],
   "outputVariable": {},
   "designation": "ldp",
-  "query": "INSERT INTO mis.coral_instances (coralid, instance_id) values (${coralItem.coralid}, '${instance.id}')",
+  "query": "INSERT INTO mis.coral_instances (coralid, instanceid) values (${coralItem.coralid}, '${instance.id}')",
   "asyncBefore": true
 }

--- a/coral-extract/nodes/saveCreatedInstanceToLDP.json
+++ b/coral-extract/nodes/saveCreatedInstanceToLDP.json
@@ -1,0 +1,22 @@
+{
+  "id": "b32e9dcc-992a-471e-8f76-769c215d3060",
+  "name": "Save Coral Id from created instance to LDP",
+  "description": "",
+  "deserializeAs": "DatabaseQueryTask",
+  "inputVariables": [
+    {
+      "key": "coralItem",
+      "type": "PROCESS",
+      "spin": true
+    },
+    {
+      "key": "instance",
+      "type": "LOCAL",
+      "spin": true
+    }
+  ],
+  "outputVariable": {},
+  "designation": "ldp",
+  "query": "INSERT INTO mis.coral_instances (coralid, instance_id) values (${coralItem.coralid}, '${instance.id}')",
+  "asyncBefore": true
+}

--- a/coral-extract/nodes/saveInstance.json
+++ b/coral-extract/nodes/saveInstance.json
@@ -17,7 +17,11 @@
       "asJson": true
     }
   ],
-  "outputVariable": {},
+  "outputVariable": {
+    "key": "instance",
+    "type": "LOCAL",
+    "spin": true
+  },
   "headerOutputVariables": [],
   "asyncBefore": true
 }

--- a/coral-extract/nodes/saveToLDP.json
+++ b/coral-extract/nodes/saveToLDP.json
@@ -12,6 +12,6 @@
   ],
   "outputVariable": {},
   "designation": "ldp",
-  "query": "INSERT INTO mis.coral_extract (coralId, contributor, title, publisher, summary, natureOfContentTerm, electronicAccess, status) values (${extractItem.coralId}, '${extractItem.contributor}', '${extractItem.title}', '${extractItem.publisher}', '${extractItem.summary}', '${extractItem.natureOfContentTerm}', '${extractItem.electronicAccess}', '${extractItem.status}')",
+  "query": "INSERT INTO mis.coral_extract (coralid, contributor, title, publisher, summary, natureOfContentTerm, electronicAccess, status) values (${extractItem.coralId}, '${extractItem.contributor}', '${extractItem.title}', '${extractItem.publisher}', '${extractItem.summary}', '${extractItem.natureOfContentTerm}', '${extractItem.electronicAccess}', '${extractItem.status}')",
   "asyncBefore": true
 }


### PR DESCRIPTION
- manually create new `mis.coral_instances` table
- perform difference between `mis.coral_extract` and `mis.coral_instances` to determine which instances to create
- insert row into `mis.coral_instances` for each instance created from coral id