### PR TITLE
Sprint13 staging workflow fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ At the end of this process, an e-mail is set to the given destination address.
 
 ```shell
 fw config set okapi-internal ***
+fw config set ldp-url ***
+fw config set ldp-user ***
+fw config set ldp-password ***
 ```
 
 These variables are required when triggering the workflow:
@@ -452,8 +455,5 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
   --form 'noteText="This is a note text message."' \
   --form 'staffOnly=false' \
   --form 'username="***"' \
-  --form 'password="***"' \
-  --form 'ldp-user="***"' \
-  --form 'ldp-password="***"' \
-  --form 'ldp-url="http://ldp.example.com/ldp"'
+  --form 'password="***"'
 ```

--- a/create-notes/nodes/connectToLDP.json
+++ b/create-notes/nodes/connectToLDP.json
@@ -3,27 +3,11 @@
   "name": "Connect to LDP",
   "description": "Connect to the LDP.",
   "deserializeAs": "DatabaseConnectionTask",
-  "inputVariables": [
-    {
-      "key": "ldp-url",
-      "type": "PROCESS",
-      "spin": false
-    },
-    {
-      "key": "ldp-user",
-      "type": "PROCESS",
-      "spin": false
-    },
-    {
-      "key": "ldp-password",
-      "type": "PROCESS",
-      "spin": false
-    }
-  ],
+  "inputVariables": [],
   "outputVariable": {},
   "designation": "ldp",
-  "url": "${ldp-url}",
-  "username": "${ldp-user}",
-  "password": "${ldp-password}",
+  "url": "{{{ldp-url}}}",
+  "username": "{{{ldp-user}}}",
+  "password": "{{{ldp-password}}}",
   "asyncBefore": true
 }

--- a/create-notes/nodes/js/processItem.js
+++ b/create-notes/nodes/js/processItem.js
@@ -37,7 +37,7 @@ if (!!itemObj) {
   if (addNote) {
     notes.push({
       'itemNoteTypeId': itemNoteTypeId,
-      'itemNotTypeName': itemNotTypeName,
+      'itemNoteTypeName': itemNoteTypeName,
       'note': noteText,
       'staffOnly': staffOnlyBoolean
     });


### PR DESCRIPTION
Fix typo in variable name that is breaking the workflow.

The revert commit 7f0db74893b55fb971ed7fcb539fc0a9f77a9c32 has been tested and confirmed to work but is no longer working.
The reason for this behavioral change is unknown.

Until the problem can be identified, reproduced, and solved, this commit is reverted.