### PR TITLE
Fix parameters sent to bookscheckout workflow and fix Workflow title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ These variables are required when triggering the workflow:
 | ldp-password            | string         | LDP login password. |
 | ldp-url                 | URL            | LDP URL. |
 | bcnMailTo               | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
-| bcnMailFrom           | e-mail address | An e-mail address used on behalf of the workflow. |
+| bcnMailFrom             | e-mail address | An e-mail address used on behalf of the workflow. |
 | mis-catalog-reports-url | URL            | URL for the MIS Catalog Reports website. |
 | logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
 

--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 fw config set bcnMailFrom ***
+fw config set bcnMailTo ***
 fw config set mis-catalog-reports-url https://localhost/catalog_reports/site
 
 ```

--- a/README.md
+++ b/README.md
@@ -476,8 +476,8 @@ These variables are required when triggering the workflow:
 | ldp-user                | string         | LDP login username. |
 | ldp-password            | string         | LDP login password. |
 | ldp-url                 | URL            | LDP URL. |
-| bcn-mail-to             | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
-| bcn-mail-from           | e-mail address | An e-mail address used on behalf of the workflow. |
+| bcnMailTo               | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
+| bcnMailFrom           | e-mail address | An e-mail address used on behalf of the workflow. |
 | mis-catalog-reports-url | URL            | URL for the MIS Catalog Reports website. |
 | logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
 
@@ -488,7 +488,7 @@ This utilizes **LDP** to get the query result which gets written to: */mnt/workf
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
-fw config set bcn-mail-from ***
+fw config set bcnMailFrom ***
 fw config set mis-catalog-reports-url https://localhost/catalog_reports/site
 
 ```
@@ -502,7 +502,7 @@ fw activate books-call-number
 
 ```
 
-User inititates form submission from catalog_reports Book-Call-Number Report.
+User initiates form submission from catalog_reports Book-Call-Number Report.
 
 Trigger the workflow using an **HTTP** request such as with **Curl**:
 
@@ -511,6 +511,6 @@ Trigger the workflow using an **HTTP** request such as with **Curl**:
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/books-call-number/start' \
   --header 'Content-Type: application/json' \
   --header 'X-Okapi-Tenant: diku' \
-  --data-raw '{"logLevel": "INFO", "bcn-mail-from": "folio@k1000.library.tamu.edu", "startRange": "a0", "endRange":"b9","username":"*","password":"*", "bcm-mail-to": "recipient@tamu.edu", "path": "/mnt/workflows/${tenantId}/bcn" }'
+  --data-raw '{"logLevel": "INFO", "bcnMailFrom": "folio@k1000.library.tamu.edu", "startRange": "a0", "endRange":"b9","username":"*","password":"*", "bcmMailTo": "recipient@tamu.edu", "path": "/mnt/workflows/${tenantId}/bcn" }'
 
 ```

--- a/README.md
+++ b/README.md
@@ -466,17 +466,20 @@ This workflow queries checked-out books within a specific call number range, gen
 
 These variables are required when triggering the workflow:
 
-| Variable Name  | Allowed Values | Short Description |
-| -------------- | -------------- | ----------------- |
-| startRange     | string         | Start Range of call number. |
-| endRange       | string         | End range of call number. |
-| username       | string         | Okapi login username. |
-| password       | string         | Okapi login password. |
-| ldp-user       | string         | LDP login username. |
-| ldp-password   | string         | LDP login password. |
-| ldp-url        | URL            | LDP URL. |
-| bcn-mail-to    | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
-| bcn-mail-from  | e-mail address | An e-mail address used on behalf of the workflow. |
+| Variable Name           | Allowed Values | Short Description |
+| --------------          | -------------- | ----------------- |
+| path                    | directory path | The directory on the system where the files, like the CSV file, are stored within on the server and contain the `tenantPath` (include trailing slash after the directory). |
+| startRange              | string         | Start Range of call number. |
+| endRange                | string         | End range of call number. |
+| username                | string         | Okapi login username. |
+| password                | string         | Okapi login password. |
+| ldp-user                | string         | LDP login username. |
+| ldp-password            | string         | LDP login password. |
+| ldp-url                 | URL            | LDP URL. |
+| bcn-mail-to             | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
+| bcn-mail-from           | e-mail address | An e-mail address used on behalf of the workflow. |
+| mis-catalog-reports-url | URL            | URL for the MIS Catalog Reports website. |
+| logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
 
 This utilizes **LDP** to get the query result which gets written to: */mnt/workflows/tamu/books-call-number* path.
 
@@ -485,7 +488,6 @@ This utilizes **LDP** to get the query result which gets written to: */mnt/workf
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
-fw config set bcn-mail-to ***
 fw config set bcn-mail-from ***
 fw config set mis-catalog-reports-url https://localhost/catalog_reports/site
 
@@ -507,8 +509,8 @@ Trigger the workflow using an **HTTP** request such as with **Curl**:
 ```shell
 
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/books-call-number/start' \
-  --header 'Content-Type: multipart/form-data' \
+  --header 'Content-Type: application/json' \
   --header 'X-Okapi-Tenant: diku' \
-  --data-raw '{"logLevel": "INFO", "bcn-mail-from": "folio@k1000.library.tamu.edu", "startRange": "a0", "endRange":"b9","username":"*","password":"*", "bcm-mail-to": "recipient@tamu.edu"}'
+  --data-raw '{"logLevel": "INFO", "bcn-mail-from": "folio@k1000.library.tamu.edu", "startRange": "a0", "endRange":"b9","username":"*","password":"*", "bcm-mail-to": "recipient@tamu.edu", "path": "/mnt/workflows/${tenantId}/bcn" }'
 
 ```

--- a/books-call-number/nodes/deleteCSVReport.json
+++ b/books-call-number/nodes/deleteCSVReport.json
@@ -9,12 +9,12 @@
       "type": "PROCESS"
     },
     {
-      "key": "tenantId",
+      "key": "path",
       "type": "PROCESS"
     }
   ],
   "outputVariable": {},
-  "path": "/mnt/workflows/${tenantId}/books-call-number/checked-out-books-report-${timestamp}.csv",
+  "path": "${path}/checked-out-books-report-${timestamp}.csv",
   "op": "DELETE",
   "asyncBefore": true
 }

--- a/books-call-number/nodes/deleteReport.json
+++ b/books-call-number/nodes/deleteReport.json
@@ -9,12 +9,12 @@
       "type": "PROCESS"
     },
     {
-      "key": "tenantId",
+      "key": "path",
       "type": "PROCESS"
     }
   ],
   "outputVariable": {},
-  "path": "/mnt/workflows/${tenantId}/books-call-number/checked-out-books-report-${timestamp}.zip",
+  "path": "${path}/checked-out-books-report-${timestamp}.zip",
   "op": "DELETE",
   "asyncBefore": true
 }

--- a/books-call-number/nodes/email.json
+++ b/books-call-number/nodes/email.json
@@ -5,7 +5,7 @@
   "deserializeAs": "EmailTask",
   "inputVariables": [
     {
-      "key": "bcn-mail-to",
+      "key": "bcnMailTo",
       "type": "PROCESS"
     },
     {
@@ -18,8 +18,8 @@
     }
   ],
   "outputVariable": {},
-  "mailTo": "{{bcn-mail-to}}",
-  "mailFrom": "{{{bcn-mail-from}}}",
+  "mailTo": "${bcnMailTo}",
+  "mailFrom": "{{{bcnMailFrom}}}",
   "mailSubject": "TAMU Checked Out Books By Call Number Report",
   "mailText": "TAMU checked out books by call number list attached",
   "attachmentPath": "${path}/checked-out-books-report-${timestamp}.zip",

--- a/books-call-number/nodes/email.json
+++ b/books-call-number/nodes/email.json
@@ -9,23 +9,19 @@
       "type": "PROCESS"
     },
     {
-      "key": "bcn-mail-from",
-      "type": "PROCESS"
-    },
-    {
       "key": "timestamp",
       "type": "PROCESS"
     },
     {
-      "key": "tenantId",
+      "key": "path",
       "type": "PROCESS"
     }
   ],
   "outputVariable": {},
-  "mailTo": "{{{bcn-mail-to}}}",
+  "mailTo": "{{bcn-mail-to}}",
   "mailFrom": "{{{bcn-mail-from}}}",
   "mailSubject": "TAMU Checked Out Books By Call Number Report",
   "mailText": "TAMU checked out books by call number list attached",
-  "attachmentPath": "/mnt/workflows/${tenantId}/books-call-number/checked-out-books-report-${timestamp}.zip",
+  "attachmentPath": "${path}/checked-out-books-report-${timestamp}.zip",
   "asyncBefore": true
 }

--- a/books-call-number/nodes/query.json
+++ b/books-call-number/nodes/query.json
@@ -9,17 +9,17 @@
       "type": "LOCAL"
     },
     {
-      "key": "tenantId",
+      "key": "timestamp",
       "type": "PROCESS"
     },
     {
-      "key": "timestamp",
+      "key": "path",
       "type": "PROCESS"
     }
   ],
   "designation": "ldp",
   "query": "${booksCallNumberQuery.prop('sql').stringValue()}",
-  "outputPath": "/mnt/workflows/${tenantId}/books-call-number/checked-out-books-report-${timestamp}.csv",
+  "outputPath": "${path}/checked-out-books-report-${timestamp}.csv",
   "resultType": "CSV",
   "includeHeader": true,
   "asyncBefore": true

--- a/books-call-number/nodes/zipReport.json
+++ b/books-call-number/nodes/zipReport.json
@@ -9,13 +9,13 @@
     "type": "PROCESS"
     },
     {
-    "key": "tenantId",
-    "type": "PROCESS"
+      "key": "path",
+      "type": "PROCESS"
     }
   ],
   "outputVariable": {},
-  "source": "/mnt/workflows/${tenantId}/books-call-number/checked-out-books-report-${timestamp}.csv",
-  "destination": "/mnt/workflows/${tenantId}/books-call-number/checked-out-books-report-${timestamp}.zip",
+  "source": "${path}/checked-out-books-report-${timestamp}.csv",
+  "destination": "${path}/checked-out-books-report-${timestamp}.zip",
   "format": "ZIP",
   "container": "NONE",
   "asyncBefore": true

--- a/books-call-number/workflow.json
+++ b/books-call-number/workflow.json
@@ -1,6 +1,6 @@
 {
   "id": "57f4ad52-6b52-42a9-adaf-91c1fc37089d",
-  "name": "Generate Checked-out List",
+  "name": "Books Checked Out By Call Number",
   "description": "Generate email containing list of checked-out books by call number.",
   "versionTag": "1.0",
   "historyTimeToLive": 90,


### PR DESCRIPTION
The `bcn-mail-to` is the correct parameter name.
The `bcn-mail-to` is being wrapped in three braces `{{{bcn-mail-to}}}` but the fw-cli substitutes these.
  - This needs to be handled as a parameter and not substituted at build time.
  - Change this to two braces so that the built workflow will access `bcn-mail-to` as an input parameter. The `path` needs to be dynamic so that the server can configure it to its local paths.

The dash (minus sign) cannot be used in this variable names and they are treated as a mathematical operation during runtime when using two braces.

Following the above changes, this then changes the `bcn-mail-to` into `bcnMailTo` and `bcn-mail-from` into `bcnMailFrom`.
This also adds a `path` variable to allow for the reports server to specify the mount path.

The _Content-Type_ for the curl example in the readme should be `'Content-Type: application/json' \`.