### PR TITLE
Replaced double curly braces with tripple

### DIFF
--- a/examples/example-emailtask/nodes/email.json
+++ b/examples/example-emailtask/nodes/email.json
@@ -12,7 +12,7 @@
   "outputVariable": {},
   "includeAttachment": false,
   "mailTo": "${exampleEmailTo}",
-  "mailFrom": "{{exampleEmailFrom}}",
+  "mailFrom": "{{{exampleEmailFrom}}}",
   "mailMarkup": "<p> Text for Email </p>",
   "mailSubject": "Example Email subject",
   "mailText": "Email Test 123",


### PR DESCRIPTION
- Replaced double curly braces with tripple curly braces in email.json to avoid html escaping