### PR TITLE
Fix problems in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ These variables are required when building and running the workflow:
 | -------------- | -------------- | ----------------- |
 | file                    | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash). |
 | logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
-| mis-catalog-reports-url | URL            | Catalog Reports URL. |
+| mis-catalog-reports-url | URL            | Catalog Reports URL (must not include a trailing slash). |
 | password                | string         | Okapi login password. |
 | path                    | directory path | The system directory where the CSV file is stored on the server that also contains the `tenantPath` (include trailing slash after the directory). |
 | username                | string         | Okapi login username.
@@ -468,7 +468,7 @@ These variables are required when building and running the workflow:
 | logLevel                     | string | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
 | locationDiscoveryDisplayName | string | A JSON Array of location names. |
 | locationName                 | string | A JSON Array of location names. |
-| mis-catalog-reports-url      | URL    | Catalog Reports URL. |
+| mis-catalog-reports-url      | URL    | Catalog Reports URL (must not include a trailing slash). |
 | resourceType                 | string | A JSON Array of resource types. |
 | suppressHoldings             | boolean | Designate whether or not Holdings should be suppressed. |
 | suppressInstance             | boolean | Designate whether or not Instances should be suppressed. |
@@ -515,7 +515,7 @@ These variables are required when building and running the workflow:
 | locationDiscoveryDisplayName | string | A JSON Array of location names. |
 | locationName                 | string | A JSON Array of location names. |
 | materialType                 | string | A JSON Array of material types. |
-| mis-catalog-reports-url      | URL    | Catalog Reports URL. |
+| mis-catalog-reports-url      | URL    | Catalog Reports URL (must not include a trailing slash). |
 | updatedDateEnd               | string | An updated end date. |
 | updatedDateStart             | string | An updated start date. |
 
@@ -723,7 +723,7 @@ These variables are required when building and running the workflow:
 | ldp-url                 | URL            | LDP URL. |
 | ldp-user                | string         | LDP login username. |
 | logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
-| mis-catalog-reports-url | URL            | Catalog Reports URL. |
+| mis-catalog-reports-url | URL            | Catalog Reports URL (must not include a trailing slash). |
 | password                | string         | Okapi login password. |
 | path                    | directory path | The directory on the system where the files, like the CSV file, are stored within on the server and contain the `tenantPath` (include trailing slash after the directory). |
 | startRange              | string         | Start Range of call number. |

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ fw activate shelflist-holdings
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/shelflist-holdings/start' \
 --header 'Content-Type: application/json' \
 --header 'X-Okapi-Tenant: diku' \
---data-raw '{ "logLevel": "INFO", "emailFrom": "me@example.com", "emailTo": "you@example.com", "libraryName": "[\"Example Library\"]", "locationDiscoveryDisplayName": "[]", "locationName": "[]", "language=": "[]", "resourceType": "[]", "format": "[]", "batchId": "", "issuance": "", "suppressInstance": false, "suppressHoldings": false, "createdDateStart": "", "createdDateEnd": "", "updatedDateStart": "", "updatedDateEnd": "" }'
+--data-raw '{ "logLevel": "INFO", "emailFrom": "me@example.com", "emailTo": "you@example.com", "libraryName": "[\"Example Library\"]", "locationDiscoveryDisplayName": "[]", "locationName": "[]", "language": "[]", "resourceType": "[]", "format": "[]", "batchId": "", "issuance": "", "suppressInstance": false, "suppressHoldings": false, "createdDateStart": "", "createdDateEnd": "", "updatedDateStart": "", "updatedDateEnd": "" }'
 ```
 
 ## shelflist-items

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Start mod-workflow and mod-camunda.
 
-```
+```shell
 cd mod-workflow
 mvn clean install
 cd service
 mvn clean spring-boot:run
 ```
 
-```
+```shell
 cd mod-camunda
 mvn clean spring-boot:run
 ```
@@ -36,15 +36,21 @@ The [Workflow](https://github.com/folio-org/mod-workflow/) JSON files are templa
 
 DivIT patron workflow. (Scheduled)
 
-> Can use fw-cli mock okapi service to test. `yarn okapi`
+These variables are required when building and running the workflow:
 
-```
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| divit-password | string         | DivIt login password. |
+| divit-url      | URL            | DivIt URL. |
+| divit-user     | string         | DivIt login username. |
+
+```shell
 fw config set divit-url ***
 fw config set divit-user ***
 fw config set divit-password ***
 ```
 
-```
+```shell
 fw build patron
 fw activate patron
 ```
@@ -53,7 +59,17 @@ fw activate patron
 
 Extract for ORCID workflow.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| divit-password  | string         | DivIt login password. |
+| divit-url       | URL            | DivIt URL. |
+| divit-user      | string         | DivIt login username. |
+| orcid-mail-from | e-mail address | The e-mail address of the sender. |
+| orcid-mail-to   | e-mail address | The e-mail address of the recipient. |
+
+```shell
 fw config set divit-url ***
 fw config set divit-user ***
 fw config set divit-password ***
@@ -61,12 +77,12 @@ fw config set orcid-mail-from ***
 fw config set orcid-mail-to ***
 ```
 
-```
+```shell
 fw build orcid
 fw activate orcid
 ```
 
-```
+```shell
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/orcid/start' \
 --header 'Content-Type: application/json' \
 --header 'X-Okapi-Tenant: diku' \
@@ -77,7 +93,17 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
 
 ISBN report to GOBI workflow. (Scheduled)
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| gobi-mail-from | e-mail address | The e-mail address of the sender. |
+| gobi-mail-to   | e-mail address | The e-mail address of the recipient. |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+
+```shell
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
@@ -85,7 +111,7 @@ fw config set gobi-mail-from ***
 fw config set gobi-mail-to ***
 ```
 
-```
+```shell
 fw build gobi
 fw activate gobi
 ```
@@ -94,23 +120,34 @@ fw activate gobi
 
 E-resource Workflow.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| divit-password | string         | DivIt login password. |
+| divit-url      | URL            | DivIt URL. |
+| divit-user     | string         | DivIt login username. |
+| resource-view  | string         | The name of the resource view. |
+
+```shell
 fw config set e-resource-view LIBRARY_ERESOURCES
 fw config set divit-url ***
 fw config set divit-user ***
 fw config set divit-password ***
 ```
 
-```
+```shell
 fw build e-resource
 fw activate e-resource
 ```
 
-```
+```shell
 fw run e-resource
+```
 
 or
 
+```shell
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/e-resource/start' \
 --header 'Content-Type: application/json' \
 --header 'X-Okapi-Tenant: diku' \
@@ -121,15 +158,41 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
 
 Purchase Orders Workflow.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| eHoldingsType   | string         | An e-holdings type to use. |
+| emailFrom       | e-mail address | The e-mail address of the sender. |
+| emailTo         | e-mail address | The e-mail address of the recipient. |
+| eMaterialType   | string         | An e-material type to use. |
+| file            | file name      | The file path within the specified directory path representing the MARC file to process. |
+| fiscalYearCode  | string         | A fiscal year code to use. |
+| logLevel        | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
+| materialType    | string         | A material type to use. |
+| noteType        | string         | A Note type. |
+| okapiUrl        | URL            | The (public or external) Okapi URL. |
+| password        | string         | Okapi login password. |
+| path            | directory path | The directory on the system where the MARC file is stored. |
+| permELocation   | string         | A permanent e-location to use. |
+| permLoanType    | string         | A permanent Loan type to use. |
+| permLocation    | string         | A permanent location to use. |
+| statisticalCode | string         | A statistical code to use. |
+| tempLoanType    | string         | A temporary Loan type to use. |
+| tempLocation    | string         | A temporary location to use. |
+| username        | string         | Okapi login username. |
+
+```shell
 fw build purchase-orders
 fw activate purchase-orders
+```
 
+```shell
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/purchase-orders/start' \
 --header 'Content-Type: multipart/form-data' \
---header 'X-Okapi-Tenant: tern' \
+--header 'X-Okapi-Tenant: diku' \
 --form 'logLevel="INFO"' \
---form 'file=@"/GOBI Print (1).mrc"' \
+--form 'file=@"/example.mrc"' \
 --form 'path="/mnt/po"' \
 --form 'statisticalCode="ybppapp"' \
 --form 'okapiUrl="https://folio-okapi-test.library.tamu.edu"' \
@@ -153,7 +216,17 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
 
 Circulation Fees/Fines Daily Report. (Scheduled)
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| ldp-password         | string         | LDP login password. |
+| ldp-url              | URL            | LDP URL. |
+| ldp-user             | string         | LDP login username. |
+| medsci-gps-zone-from | e-mail address | The e-mail address of the sender. |
+| medsci-gps-zone-to   | e-mail address | The e-mail address of the recipient. |
+
+```shell
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
@@ -161,7 +234,7 @@ fw config set circ-fines-mail-from ***
 fw config set circ-fines-mail-to ***
 ```
 
-```
+```shell
 fw build circ-fines
 fw activate circ-fines
 ```
@@ -170,13 +243,21 @@ fw activate circ-fines
 
 Rapid ILS Print Serials Monthly Report. (Scheduled)
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+
+```shell
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
 
-```
+```shell
 fw build rapid-print-serials
 fw activate rapid-print-serials
 ```
@@ -185,13 +266,21 @@ fw activate rapid-print-serials
 
 Rapid ILS Print Monos Monthly Report. (Scheduled)
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+
+```shell
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
 
-```
+```shell
 fw build rapid-print-monos
 fw activate rapid-print-monos
 ```
@@ -200,7 +289,7 @@ fw activate rapid-print-monos
 
 Rapid ILS Electronic Serials Monthly Report. (Scheduled)
 
-```
+```shell
 fw build rapid-electronic-serials
 fw activate rapid-electronic-serials
 ```
@@ -240,25 +329,32 @@ CONSTRAINT coral_instances_pkey PRIMARY KEY (coralid)
 );
 ```
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| coral-url      | URL            | Coral server URL. |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+
+```shell
 fw config set coral-url ***
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
 
-```
+```shell
 fw build coral-extract
 fw activate coral-extract
 ```
 
-```
+```shell
 fw run coral-extract
-
-or
-
-Wait for the cron job to execute.
 ```
+
+or wait for the cron job to be auto-triggered.
 
 ## medsci-gps-zone
 
@@ -266,7 +362,17 @@ MedSci GPS Zone
 
 For the `medsci-gps-zone-file` setting, the file name (without the path part) should likely be `grad_access.txt`.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| divit-password       | string         | DivIt login password. |
+| divit-url            | URL            | DivIt URL. |
+| divit-user           | string         | DivIt login username. |
+| medsci-gps-zone-from | e-mail address | The e-mail address of the sender. |
+| medsci-gps-zone-to   | e-mail address | The e-mail address of the recipient. |
+
+```shell
 fw config set divit-url ***
 fw config set divit-user ***
 fw config set divit-password ***
@@ -274,12 +380,12 @@ fw config set medsci-gps-zone-from ***
 fw config set medsci-gps-zone-to ***
 ```
 
-```
+```shell
 fw build medsci-gps-zone
 fw activate medsci-gps-zone
 ```
 
-```
+```shell
 fw run medsci-gps-zone
 ```
 
@@ -287,18 +393,26 @@ fw run medsci-gps-zone
 
 HathiTrust Export
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+
+```shell
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
 
-```
+```shell
 fw build hathitrust
 fw activate hathitrust
 ```
 
-```
+```shell
 fw run hathitrust
 ```
 
@@ -306,14 +420,25 @@ fw run hathitrust
 
 Create Tags Workflow.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| file                    | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash). |
+| logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
+| mis-catalog-reports-url | URL            | Catalog Reports URL. |
+| password                | string         | Okapi login password. |
+| path                    | directory path | The system directory where the CSV file is stored on the server that also contains the `tenantPath` (include trailing slash after the directory). |
+| username                | string         | Okapi login username.
+
+```shell
 fw build create-tags
 fw activate create-tags
 
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/create-tags/start' \
 --header 'Content-Type: multipart/form-data' \
---header 'X-Okapi-Tenant: tamu' \
---form 'logLevel="DEBUG"' \
+--header 'X-Okapi-Tenant: diku' \
+--form 'logLevel="INFO"' \
 --form 'file=@"FOLIOTags.csv"' \
 --form 'path="/mnt/workflows/diku/create-tags"' \
 --form 'username="***"' \
@@ -324,57 +449,114 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
 
 Shelflist (holdings level) Report Workflow.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| batchId                      | UUID   | A batch ID. |
+| createdDateEnd               | string | A created end date. |
+| createdDateStart             | string | A created start date. |
+| emailFrom                    | e-mail address | The e-mail address of the sender. |
+| emailTo                      | e-mail address | The e-mail address of the recipient. |
+| format                       | string | A JSON Array of formats. |
+| issuance                     | string | An issuance name. |
+| language                     | string | A JSON Array of languages. |
+| ldp-password                 | string | LDP login password. |
+| ldp-url                      | URL    | LDP URL. |
+| ldp-user                     | string | LDP login username. |
+| libraryName                  | string | A JSON Array of library names. |
+| logLevel                     | string | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
+| locationDiscoveryDisplayName | string | A JSON Array of location names. |
+| locationName                 | string | A JSON Array of location names. |
+| mis-catalog-reports-url      | URL    | Catalog Reports URL. |
+| resourceType                 | string | A JSON Array of resource types. |
+| suppressHoldings             | boolean | Designate whether or not Holdings should be suppressed. |
+| suppressInstance             | boolean | Designate whether or not Instances should be suppressed. |
+| updatedDateEnd               | string | An updated end date. |
+| updatedDateStart             | string | An updated start date. |
+
+```shell
 fw config set mis-catalog-reports-url https://localhost/catalog_reports/site
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
 
-```
+```shell
 fw build shelflist-holdings
 fw activate shelflist-holdings
 
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/shelflist-holdings/start' \
 --header 'Content-Type: application/json' \
---header 'X-Okapi-Tenant: tern' \
---data-raw '{ "logLevel": "INFO", "emailFrom": "folio@k1000.library.tamu.edu", "emailTo": "workflows@library.tamu.edu", "libraryName': "[\"Texas A&M University Qatar Library\"], "locationDiscoveryDisplayName": "[]", "locationName": "[]", "language=": "[]", "resourceType": "[]", "format": "[]", "batchId": "", "issuance": "", "suppressInstance": false, "suppressHoldings": false, "createdDateStart": "", "createdDateEnd": "", "updatedDateStart": "", "updatedDateEnd": "" }'
-
+--header 'X-Okapi-Tenant: diku' \
+--data-raw '{ "logLevel": "INFO", "emailFrom": "me@example.com", "emailTo": "you@example.com", "libraryName": "[\"Example Library\"]", "locationDiscoveryDisplayName": "[]", "locationName": "[]", "language=": "[]", "resourceType": "[]", "format": "[]", "batchId": "", "issuance": "", "suppressInstance": false, "suppressHoldings": false, "createdDateStart": "", "createdDateEnd": "", "updatedDateStart": "", "updatedDateEnd": "" }'
 ```
 
 ## shelflist-items
 
 Shelflist (items level) Report Workflow.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| batchId                      | UUID   | A batch ID. |
+| createdDateEnd               | string | A created end date. |
+| createdDateStart             | string | A created start date. |
+| emailFrom                    | e-mail address | The e-mail address of the sender. |
+| emailTo                      | e-mail address | The e-mail address of the recipient. |
+| itemStatus                   | string | A JSON Array of Item statuses. |
+| ldp-password                 | string | LDP login password. |
+| ldp-url                      | URL    | LDP URL. |
+| ldp-user                     | string | LDP login username. |
+| libraryName                  | string | A JSON Array of library names. |
+| loanType                     | string | A JSON Array of loan types. |
+| logLevel                     | string | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
+| locationDiscoveryDisplayName | string | A JSON Array of location names. |
+| locationName                 | string | A JSON Array of location names. |
+| materialType                 | string | A JSON Array of material types. |
+| mis-catalog-reports-url      | URL    | Catalog Reports URL. |
+| updatedDateEnd               | string | An updated end date. |
+| updatedDateStart             | string | An updated start date. |
+
+```shell
 fw config set mis-catalog-reports-url https://localhost/catalog_reports/site
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
 
-```
+```shell
 fw build shelflist-holdings
 fw activate shelflist-holdings
+```
 
+```shell
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/shelflist-items/start' \
 --header 'Content-Type: application/json' \
---header 'X-Okapi-Tenant: tern' \
---data-raw '{ "logLevel": "INFO", "emailFrom": "folio@k1000.library.tamu.edu", "emailTo": "workflows@library.tamu.edu", "libraryName": "[\"Texas A&M University Qatar Library\"] ", "locationDiscoveryDisplayName": "[]", "locationName": "[]", "loanType": "[]", "materialType": "[]", "itemStatus": "[]", "createdDateStart": "", "createdDateEnd": "", "updatedDateStart": "", "updatedDateEnd": "" }'
-
+--header 'X-Okapi-Tenant: diku' \
+--data-raw '{ "logLevel": "INFO", "emailFrom": "me@example.com", "emailTo": "you@example.com", "libraryName": "[\"Example Library\"]", "locationDiscoveryDisplayName": "[]", "locationName": "[]", "loanType": "[]", "materialType": "[]", "itemStatus": "[]", "createdDateStart": "", "createdDateEnd": "", "updatedDateStart": "", "updatedDateEnd": "" }'
 ```
 
 ## item-history-update
 
 Item History Update Workflow.
 
-```
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+
+```shell
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
 
-```
+```shell
 fw build item-history-update
 fw activate item-history-update
 fw run item-history-update
@@ -391,6 +573,17 @@ This utilizes **LDP** in order to fine-tune the query in ways not normally allow
 These fetched *Items* are then used to fetch an up to date version using the appropriate **FOLIO** **REST** end point and updates the *Items* as appropriate using the appropriate **FOLIO** **REST** end point.
 
 The scheduled event is for **12:00pm UTC**, which is **7:00am in CDT**.
+
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+| okapi-internal | URL            | The (internal) Okapi URL. |
+| password       | string         | Okapi login password. |
+| username       | string         | Okapi login username. |
 
 ```shell
 fw config set ldp-url ***
@@ -424,30 +617,31 @@ These fetched *Items* are then used to fetch an up to date version using the app
 
 At the end of this process, an e-mail is set to the given destination address.
 
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| emailFrom      | e-mail address | The e-mail address of the sender. |
+| emailTo        | e-mail address | The e-mail address of the recipient. |
+| file           | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash). |
+| itemNoteTypeId | UUID           | The Item Note Type UUID to be used for the Note. |
+| noteText       | string         | A message used as the Note. |
+| ldp-password   | string         | LDP login password. |
+| ldp-url        | URL            | LDP URL. |
+| ldp-user       | string         | LDP login username. |
+| logLevel       | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
+| okapi-internal | URL            | The (internal) Okapi URL. |
+| password       | string         | Okapi login password. |
+| path           | directory path | The system directory where the CSV file is stored on the server that also contains the `tenantPath` (include trailing slash after the directory). |
+| staffOnly      | boolean        | Designate whether or not this is a *Staff Only* note. |
+| username       | string         | Okapi login username. |
+
 ```shell
 fw config set okapi-internal ***
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 ```
-
-These variables are required when triggering the workflow:
-
-| Variable Name  | Allowed Values | Short Description |
-| -------------- | -------------- | ----------------- |
-| path           | directory path | The directory on the system where the CSV file is stored within on the server and contain the `tenantPath` (include trailing slash after the directory). |
-| file           | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash). |
-| emailFrom      | e-mail address | An e-mail address used as the "FROM" in the sent e-mails. |
-| emailTo        | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
-| itemNoteTypeId | UUID           | The Item Note Type UUID to be used for the Note. |
-| noteText       | string         | A message used as the Note. |
-| staffOnly      | boolean        | Designate whether or not this is a *Staff Only* note. |
-| username       | string         | Okapi login username. |
-| password       | string         | Okapi login password. |
-| ldp-user       | string         | LDP login username. |
-| ldp-password   | string         | LDP login password. |
-| ldp-url        | URL            | LDP URL. |
-
 
 To build and activate:
 ```shell
@@ -461,8 +655,8 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
   --header 'Content-Type: multipart/form-data' \
   --header 'X-Okapi-Tenant: diku' \
   --form 'logLevel="INFO"' \
-  --form 'emailFrom="folio@k1000.library.tamu.edu"' \
-  --form 'emailTo="workflows@library.tamu.edu"' \
+  --form 'emailFrom="me@example.com"' \
+  --form 'emailTo="you@example.com"' \
   --form 'file=@"itemBarcodes.csv"' \
   --form 'path="/mnt/workflows/diku/create-notes/"' \
   --form 'itemNoteTypeId="d5684236-e4ab-4a64-97b3-2aa7a595cfc4"' \
@@ -476,22 +670,22 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
 
 For the uploaded CSV of call numbers, remove items that have been on the new bookshelf location for more than 30 days.
 
+These variables are required when building and running the workflow:
+
+| Variable Name  | Allowed Values | Brief Description |
+| -------------- | -------------- | ----------------- |
+| nbs-mail-from  | e-mail address | The e-mail address of the sender. |
+| emailTo        | e-mail address | The e-mail address of the recipient. |
+| file           | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash). |
+| logLevel       | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
+| password       | string         | Okapi login password. |
+| path           | directory path | The system directory where the CSV file is stored on the server that also contains the `tenantPath` (include trailing slash after the directory). |
+| username       | string         | Okapi login username. |
+
 ```shell
 fw config set okapi-internal ***
 fw config set nbs-mail-from ***
 ```
-
-These variables are required when triggering the workflow:
-
-| Variable Name  | Allowed Values | Short Description |
-| -------------- | -------------- | ----------------- |
-| path           | directory path | The directory on the system where the CSV file is stored within on the server and contain the `tenantPath` (include trailing slash after the directory). |
-| file           | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash). |
-| emailTo        | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
-| username       | string         | Okapi login username. |
-| password       | string         | Okapi login password. |
-| logLevel       | [INFO,DEBUG]   | Desired log level |
-
 
 To build and activate:
 ```shell
@@ -505,7 +699,7 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
   --header 'Content-Type: multipart/form-data' \
   --header 'X-Okapi-Tenant: diku' \
   --form 'logLevel="INFO"' \
-  --form 'emailTo="workflows@library.tamu.edu"' \
+  --form 'emailTo="you@example.com"' \
   --form 'file=@"itemBarcodes.csv"' \
   --form 'path="/mnt/workflows/diku/remove-books-from-nbs/"' \
   --form 'username="***"' \
@@ -518,55 +712,49 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
 
 This workflow queries checked-out books within a specific call number range, generates a list, and emails this list to the specified recipient.
 
-These variables are required when triggering the workflow:
+These variables are required when building and running the workflow:
 
-| Variable Name           | Allowed Values | Short Description |
+| Variable Name           | Allowed Values | Brief Description |
 | --------------          | -------------- | ----------------- |
-| path                    | directory path | The directory on the system where the files, like the CSV file, are stored within on the server and contain the `tenantPath` (include trailing slash after the directory). |
-| startRange              | string         | Start Range of call number. |
+| bcnMailFrom             | e-mail address | The e-mail address of the sender. |
+| bcnMailTo               | e-mail address | The e-mail address of the recipient. |
 | endRange                | string         | End range of call number. |
-| username                | string         | Okapi login username. |
-| password                | string         | Okapi login password. |
-| ldp-user                | string         | LDP login username. |
 | ldp-password            | string         | LDP login password. |
 | ldp-url                 | URL            | LDP URL. |
-| bcnMailTo               | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
-| bcnMailFrom             | e-mail address | An e-mail address used as the "FROM" in the sent e-mails. |
-| mis-catalog-reports-url | URL            | URL for the MIS Catalog Reports website. |
+| ldp-user                | string         | LDP login username. |
 | logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
+| mis-catalog-reports-url | URL            | Catalog Reports URL. |
+| password                | string         | Okapi login password. |
+| path                    | directory path | The directory on the system where the files, like the CSV file, are stored within on the server and contain the `tenantPath` (include trailing slash after the directory). |
+| startRange              | string         | Start Range of call number. |
+| username                | string         | Okapi login username. |
 
 This utilizes **LDP** to get the query result which gets written to: */mnt/workflows/tamu/books-call-number* path.
 
 ```shell
-
 fw config set ldp-url ***
 fw config set ldp-user ***
 fw config set ldp-password ***
 fw config set bcnMailFrom ***
 fw config set mis-catalog-reports-url https://localhost/catalog_reports/site
-
 ```
 
 To build and activate:
 
 ```shell
-
 fw build books-call-number
 fw activate books-call-number
-
 ```
 
-User inititates form submission from catalog_reports Book-Call-Number Report.
+The user initiates the form submission using the Catalog Reports Book-Call-Number Report.
 
 Trigger the workflow using an **HTTP** request such as with **Curl**:
 
 ```shell
-
 curl --location --request POST 'http://localhost:9001/mod-workflow/events/workflow/books-call-number/start' \
   --header 'Content-Type: application/json' \
   --header 'X-Okapi-Tenant: diku' \
-  --data-raw '{"logLevel": "INFO", "bcn-mail-from": "folio@k1000.library.tamu.edu", "startRange": "a0", "endRange":"b9","username":"*","password":"*", "bcm-mail-to": "recipient@tamu.edu", "path": "/mnt/workflows/diku/bcn" }'
-
+  --data-raw '{"logLevel": "INFO", "startRange": "a0", "endRange":"b9","username":"*","password":"*", "bcnMailTo": "recipient@tamu.edu", "path": "/mnt/workflows/diku/bcn" }'
 ```
 
 ## evans-pres-repr
@@ -575,16 +763,16 @@ curl --location --request POST 'http://localhost:9001/mod-workflow/events/workfl
 
 This workflow sends a monthly email containing a list of all items with 'temporary location' set to "Eva Pres Repr" to a specifically configured email address `evansPresReprFrom`.
 
-These variables are required when triggering the workflow:
+These variables are required when building and running the workflow:
 
-| Variable Name           | Allowed Values | Short Description |
+| Variable Name           | Allowed Values | Brief Description |
 | --------------          | -------------- | ----------------- |
+| evansPresReprFrom       | e-mail address | The e-mail address of the sender. |
+| evansPresReprTo         | e-mail address | The e-mail address of the recipient. |
 | ldp-url                 | URL            | LDP URL. |
 | ldp-user                | string         | LDP login username. |
 | ldp-password            | string         | LDP login password. |
 | logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG". |
-| evansPresReprTo         | e-mail address | An e-mail address used as the "TO" in the sent e-mails. |
-| evansPresReprFrom       | e-mail address | An e-mail address used as the "FROM" in the sent e-mails. |
 
 This utilizes **LDP** to get the query result which gets written to: */mnt/workflows/tamu/evans-pres-repr* path.
 


### PR DESCRIPTION
Make the README structure slightly more consistent. This only addresses some, but not all, of the inconsistency problems.

Improve the grammar and language being used.

Use `shell` more consistently to better improve presentation on render.

The examples showing `X-Okapi-Tenant:` are inconsistent.

The documentation describing the files and paths in some cases are incorrect.

Make the variable table more consistently used.
I had to glance at the requirements and so there may be more things to fix regarding this. In some cases I discovered that the examples are entirely wrong and reference incorrect or non-existent variables.

Get rid of TAMU-specific information.
The examples should just be examples and should not be tied to some institution or system.

Use alphabetical ordering in the table to make searching the variable names easier.