### PR TITLE
Improve debug logging of Purchase Order workflow.

### DIFF
--- a/purchase-orders/nodes/js/extractInstanceIdFromPoLine.js
+++ b/purchase-orders/nodes/js/extractInstanceIdFromPoLine.js
@@ -1,5 +1,9 @@
 var compositePurchaseOrderObj = JSON.parse(compositePurchaseOrder);
 
+if (logLevel === 'DEBUG') {
+  print('\ncompositePurchaseOrder = ' + compositePurchaseOrder + '\n');
+}
+
 var instanceId = compositePurchaseOrderObj.compositePoLines[0].instanceId;
 
 execution.setVariable('instanceId', instanceId);

--- a/purchase-orders/nodes/js/prepareInstance.js
+++ b/purchase-orders/nodes/js/prepareInstance.js
@@ -37,7 +37,7 @@ mappedInstanceObj.statisticalCodeIds = mapStatisticalCodeIds(statisticalCodes);
 mappedInstanceObj._version = 1;
 
 if (logLevel === 'DEBUG') {
-  print('\ninstance = ' + JSON.stringify(mappedInstanceObj) + '\n');
+  print('\nmappedInstance = ' + JSON.stringify(mappedInstanceObj) + '\n');
 }
 
 execution.setVariable('instance', S(JSON.stringify(mappedInstanceObj)));


### PR DESCRIPTION
Rename `instance` to `mappedInstance` in log to make it more clear that the given log is after being mapped.

Add a log for the `compositePurchaseOrder` to be printed.

These log improvements helped track down the issue for #397 .