### PR TITLE
Add ability to override patron e-mails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,18 @@ DivIT patron workflow. (Scheduled)
 
 These variables are required when building and running the workflow:
 
-| Variable Name  | Allowed Values | Brief Description |
-| -------------- | -------------- | ----------------- |
-| divit-password | string         | DivIt login password. |
-| divit-url      | URL            | DivIt URL. |
-| divit-user     | string         | DivIt login username. |
+|    Variable Name    | Allowed Values | Brief Description |
+| ------------------- | -------------- | ----------------- |
+| divit-password      | string         | DivIt login password. |
+| divit-url           | URL            | DivIt URL. |
+| divit-user          | string         | DivIt login username. |
+| overridePatronEmail | string or null | Forcibly replace all e-mails with this (for testing and debugging only). |
 
 ```shell
 fw config set divit-url ***
 fw config set divit-user ***
 fw config set divit-password ***
+fw config set overridePatronEmail ***
 ```
 
 ```shell

--- a/patron/nodes/js/transform.js
+++ b/patron/nodes/js/transform.js
@@ -30,6 +30,10 @@ function tranform(patrons) {
     personal.phone = FormatUtility.normalizePhoneNumber(patron.personal_phone);
     personal.preferredContactTypeId = 'email';
 
+    if ("{{{overridePatronEmail}}}" != "") {
+      personal.email = "{{{overridePatronEmail}}}";
+    }
+
     if (patron.addresses_permanent_addressLine1) {
       var permanentAddress = {};
 


### PR DESCRIPTION
Valid e-mails are generally replaced after migrating production data into a development environment.
This workflow has the potential for re-adding authentic production e-mails.

This provides a way to forcibly guarantee that a stub/alternative e-mail is used for every single account to be imported.
This adds only a single e-mail address to all accounts being transformed based on a build time variable.