### PR TITLE
Fix electronic serials gz file txt extention

### DIFF
--- a/rapid-electronic-serials/nodes/gzipRapidElectronicSerialsTSV.json
+++ b/rapid-electronic-serials/nodes/gzipRapidElectronicSerialsTSV.json
@@ -18,7 +18,7 @@
     "type": "PROCESS"
   },
   "source": "${sfxFile}",
-  "destination": "/mnt/workflows/${tenantId}/rapid/rapid_electronic_serials.gz",
+  "destination": "/mnt/workflows/${tenantId}/rapid/rapid_electronic_serials.txt.gz",
   "format": "GZIP",
   "container": "NONE",
   "asyncBefore": true


### PR DESCRIPTION
**Problem:** After the `rapid-electronic-serials` workflow was run, the output file name was `rapid_electronic_serials.gz` rather than `rapid_electronic_serials.txt.gz`.

I've changed it tested it and produced the right output file.