### PR TITLE
RTR 464-472: Okapi changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ These variables are required when building and running the workflow:
 | divit-password      | string         | DivIt login password.
 | divit-url           | URL            | DivIt URL.
 | divit-user          | string         | DivIt login username.
+| okapi-url           | URL            | The Okapi URL.
 | overridePatronEmail | string or null | Forcibly replace all e-mails with this (for testing and debugging only).
 
 ```shell
 fw config set divit-url ***
 fw config set divit-user ***
 fw config set divit-password ***
+fw config set okapi-url ***
 fw config set overridePatronEmail ***
 ```
 
@@ -190,8 +192,7 @@ These variables are required when building and running the workflow:
 | logLevel         | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG".
 | materialType     | string         | A material type to use.
 | noteType         | string         | A Note type.
-| okapiUrl         | URL            | The (public or external) Okapi URL.
-| okapi-internal   | URL            | The (internal) Okapi URL.
+| okapi-url        | URL            | The Okapi URL.
 | password         | string         | Okapi login password.
 | path             | directory path | The directory on the system where the MARC file is stored.
 | permELocation    | string         | A permanent e-location to use.
@@ -203,7 +204,7 @@ These variables are required when building and running the workflow:
 | username         | string         | Okapi login username.
 
 ```shell
-fw config set okapi-internal ***
+fw config set okapi-url ***
 ```
 
 ```shell
@@ -226,7 +227,6 @@ curl -w '\n' --location --request POST 'http://localhost:9001/events/purchase-or
 --form 'logLevel="INFO"' \
 --form 'materialType="unmediated -- volume"' \
 --form 'noteType="General note"' \
---form 'okapiUrl="https://okapi"' \
 --form 'password="***"' \
 --form 'path="/mnt/po"' \
 --form 'permELocation="www_evans"' \
@@ -494,12 +494,14 @@ The following variables are required when building and running the workflow:
 | metadb-password | string         | MetaDB login password.
 | metadb-url      | URL            | MetaDB URL.
 | metadb-user     | string         | MetaDB login username.
+| okapi-url       | URL            | The Okapi URL.
 
 ```shell
 fw config set coral-url ***
 fw config set metadb-url ***
 fw config set metadb-user ***
 fw config set metadb-password ***
+fw config set okapi-url ***
 ```
 
 ```shell
@@ -587,9 +589,14 @@ These variables are required when building and running the workflow:
 | file                    | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash).
 | logLevel                | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG".
 | mis-catalog-reports-url | URL            | Catalog Reports URL (must not include a trailing slash).
+| okapi-url               | URL            | The Okapi URL.
 | password                | string         | Okapi login password.
 | path                    | directory path | The system directory where the CSV file is stored on the server that also contains the `tenantPath` (include trailing slash after the directory).
 | username                | string         | Okapi login username.
+
+```shell
+fw config set okapi-url ***
+```
 
 ```shell
 fw build create-tags
@@ -746,7 +753,7 @@ These variables are required when building and running the workflow:
 | metadb-password | string         | MetaDB login password.
 | metadb-url      | URL            | MetaDB URL.
 | metadb-user     | string         | MetaDB login username.
-| okapi-internal  | URL            | The (internal) Okapi URL.
+| okapi           | URL            | The Okapi URL.
 | password        | string         | Okapi login password.
 | username        | string         | Okapi login username.
 
@@ -754,7 +761,7 @@ These variables are required when building and running the workflow:
 fw config set metadb-url ***
 fw config set metadb-user ***
 fw config set metadb-password ***
-fw config set okapi-internal ***
+fw config set okapi-url ***
 fw config set username ***
 fw config set password ***
 ```
@@ -797,17 +804,17 @@ These variables are required when building and running the workflow:
 | metadb-url      | URL            | MetaDB URL.
 | metadb-user     | string         | MetaDB login username.
 | logLevel        | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG".
-| okapi-internal  | URL            | The (internal) Okapi URL.
+| okapi-url       | URL            | The Okapi URL.
 | password        | string         | Okapi login password.
 | path            | directory path | The system directory where the CSV file is stored on the server that also contains the `tenantPath` (include trailing slash after the directory).
 | staffOnly       | boolean        | Designate whether or not this is a *Staff Only* note.
 | username        | string         | Okapi login username.
 
 ```shell
-fw config set okapi-internal ***
 fw config set metadb-url ***
 fw config set metadb-user ***
 fw config set metadb-password ***
+fw config set okapi-url ***
 ```
 
 To build and activate:
@@ -846,13 +853,14 @@ These variables are required when building and running the workflow:
 | emailTo        | e-mail address | The e-mail address of the recipient.
 | file           | file name      | The file path within the specified directory path representing the CSV file to process (do not prefix with a starting slash).
 | logLevel       | string         | Designate the desired logging, such as "INFO", "WARN", or "DEBUG".
+| okapi-url      | URL            | The Okapi URL.
 | password       | string         | Okapi login password.
 | path           | directory path | The system directory where the CSV file is stored on the server that also contains the `tenantPath` (include trailing slash after the directory).
 | username       | string         | Okapi login username.
 
 ```shell
-fw config set okapi-internal ***
 fw config set nbs-mail-from ***
+fw config set okapi-url ***
 ```
 
 To build and activate:

--- a/coral-extract/nodes/end.json
+++ b/coral-extract/nodes/end.json
@@ -1,6 +1,6 @@
 {
   "id": "8c9e268e-6302-44c9-8bdf-4f5830c26deb",
   "name": "End",
-  "description": "",
+  "description": "Finished the Coral Extract workflow.",
   "deserializeAs": "EndEvent"
 }

--- a/coral-extract/nodes/folioLogin.json
+++ b/coral-extract/nodes/folioLogin.json
@@ -1,14 +1,14 @@
 {
-  "id": "f3f35f6b-42fb-4fe6-aab6-b35abba5a8a2",
-  "name": "Okapi Login",
-  "description": "Login to Okapi.",
+  "id": "88ebbebe-5992-4262-bc7b-269d6be38885",
+  "name": "FOLIO Login",
+  "description": "Log into FOLIO, obtaining the appropriate tokens.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/authn/login",
+    "url": "{{{okapi-url}}}/authn/login-with-expiry",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",
-    "bodyTemplate": "{\"username\": \"${username}\",\"password\": \"${password}\"}"
+    "bodyTemplate": "{\"username\": \"{{{username}}}\", \"password\": \"{{{password}}}\"}"
   },
   "inputVariables": [
     {
@@ -22,13 +22,14 @@
   ],
   "headerOutputVariables": [
     {
-      "key": "X-Okapi-Token",
-      "type": "PROCESS"
+      "key": "Set-Cookie",
+      "type": "LOCAL",
+      "asArray": true
     }
   ],
   "outputVariable": {
     "key": "loginResponse",
-    "type": "PROCESS"
+    "type": "LOCAL"
   },
   "asyncBefore": true
 }

--- a/coral-extract/nodes/getAccessToken.json
+++ b/coral-extract/nodes/getAccessToken.json
@@ -1,0 +1,8 @@
+{
+  "id": "aa31457b-f0e8-48a6-9f7c-447c9903d712",
+  "name": "Get Access Token",
+  "description": "Get the FOLIO Access Token as an X-Okapi-Token.",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "getAccessToken.js"
+}

--- a/coral-extract/nodes/js/getAccessToken.js
+++ b/coral-extract/nodes/js/getAccessToken.js
@@ -1,0 +1,25 @@
+const TokenUtility = Java.type('org.folio.rest.camunda.utility.TokenUtility');
+
+/**
+ * Get the named headers, if defined.
+ *
+ * This requires that the `asArray` for the `headerOutputVariables` variable to be set to TRUE.
+ *
+ * Note: The scripts have access to all variables available and so do not specifically require the "inputVariables" to be defined.
+ *
+ * @param {string} name - The headers name to fetch.
+ *
+ * @return {string} The value of the named headers, or undefined.
+ */
+function getHeaders(name) {
+  if (execution.hasVariable(name)) {
+    return execution.getVariableTyped(name, true).getValue();
+  }
+}
+
+(function () {
+  const setCookie = getHeaders("Set-Cookie");
+  const accessToken = TokenUtility.getAccessTokens(setCookie);
+
+  execution.setVariable('X-Okapi-Token', accessToken);
+}());

--- a/coral-extract/nodes/saveHoldings.json
+++ b/coral-extract/nodes/saveHoldings.json
@@ -4,7 +4,7 @@
   "description": "",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/holdings-storage/holdings",
+    "url": "{{{okapi-url}}}/holdings-storage/holdings",
     "method": "POST",
     "accept": "application/json",
     "bodyTemplate": "${holdings}"

--- a/coral-extract/nodes/saveInstance.json
+++ b/coral-extract/nodes/saveInstance.json
@@ -4,7 +4,7 @@
   "description": "",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/instance-storage/instances",
+    "url": "{{{okapi-url}}}/instance-storage/instances",
     "method": "POST",
     "accept": "application/json",
     "bodyTemplate": "${instance}"

--- a/coral-extract/nodes/start.json
+++ b/coral-extract/nodes/start.json
@@ -1,7 +1,7 @@
 {
   "id": "7dac827f-890e-45bc-b5be-13baecc9dc2f",
   "name": "Start",
-  "description": "",
+  "description": "Start the Coral Extract workflow based on a time event.",
   "type": "SCHEDULED",
   "deserializeAs": "StartEvent",
   "expression": "0 0 15 * * ?"

--- a/coral-extract/workflow.json
+++ b/coral-extract/workflow.json
@@ -22,6 +22,7 @@
     "/databaseQueryTask/1b24cb49-bbbc-4b3d-9351-502b86aa790e",
     "/databaseDisconnectTask/e3a30113-53ee-46ce-8404-1ffbb3f53bec",
     "/requestTask/88ebbebe-5992-4262-bc7b-269d6be38885",
+    "/scriptTask/aa31457b-f0e8-48a6-9f7c-447c9903d712",
     "/subprocess/a74c0421-5d97-4608-bb85-eb14adebd23d",
     "/endEvent/8c9e268e-6302-44c9-8bdf-4f5830c26deb"
   ],

--- a/create-notes/nodes/folioLogin.json
+++ b/create-notes/nodes/folioLogin.json
@@ -1,14 +1,14 @@
 {
-  "id": "88ebbebe-5992-4262-bc7b-269d6be38885",
-  "name": "Okapi Login",
-  "description": "Okapi Login",
+  "id": "f3f35f6b-42fb-4fe6-aab6-b35abba5a8a2",
+  "name": "FOLIO Login",
+  "description": "Log into FOLIO, obtaining the appropriate tokens.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/authn/login",
+    "url": "{{{okapi-url}}}/authn/login-with-expiry",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",
-    "bodyTemplate": "{\"username\": \"{{{username}}}\", \"password\": \"{{{password}}}\"}"
+    "bodyTemplate": "{\"username\": \"${username}\",\"password\": \"${password}\"}"
   },
   "inputVariables": [
     {
@@ -22,13 +22,14 @@
   ],
   "headerOutputVariables": [
     {
-      "key": "X-Okapi-Token",
-      "type": "PROCESS"
+      "key": "Set-Cookie",
+      "type": "LOCAL",
+      "asArray": true
     }
   ],
   "outputVariable": {
     "key": "loginResponse",
-    "type": "PROCESS"
+    "type": "LOCAL"
   },
   "asyncBefore": true
 }

--- a/create-notes/nodes/getAccessToken.json
+++ b/create-notes/nodes/getAccessToken.json
@@ -1,0 +1,8 @@
+{
+  "id": "0cf53af7-c545-4632-9eff-f799f572afe6",
+  "name": "Get Access Token",
+  "description": "Get the FOLIO Access Token as an X-Okapi-Token.",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "getAccessToken.js"
+}

--- a/create-notes/nodes/js/getAccessToken.js
+++ b/create-notes/nodes/js/getAccessToken.js
@@ -1,0 +1,25 @@
+const TokenUtility = Java.type('org.folio.rest.camunda.utility.TokenUtility');
+
+/**
+ * Get the named headers, if defined.
+ *
+ * This requires that the `asArray` for the `headerOutputVariables` variable to be set to TRUE.
+ *
+ * Note: The scripts have access to all variables available and so do not specifically require the "inputVariables" to be defined.
+ *
+ * @param {string} name - The headers name to fetch.
+ *
+ * @return {string} The value of the named headers, or undefined.
+ */
+function getHeaders(name) {
+  if (execution.hasVariable(name)) {
+    return execution.getVariableTyped(name, true).getValue();
+  }
+}
+
+(function () {
+  const setCookie = getHeaders("Set-Cookie");
+  const accessToken = TokenUtility.getAccessTokens(setCookie);
+
+  execution.setVariable('X-Okapi-Token', accessToken);
+}());

--- a/create-notes/nodes/requestItem.json
+++ b/create-notes/nodes/requestItem.json
@@ -4,7 +4,7 @@
   "description": "Request the Item by its given Item ID.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/items/${item.id}",
+    "url": "{{{okapi-url}}}/inventory/items/${item.id}",
     "method": "GET",
     "accept": "application/json"
   },

--- a/create-notes/nodes/updateItem.json
+++ b/create-notes/nodes/updateItem.json
@@ -4,7 +4,7 @@
   "description": "Update the Item using the appropriate REST request.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/items/${itemId}",
+    "url": "{{{okapi-url}}}/inventory/items/${itemId}",
     "method": "PUT",
     "contentType": "application/json",
     "accept": "text/plain",

--- a/create-notes/workflow.json
+++ b/create-notes/workflow.json
@@ -13,6 +13,7 @@
   "nodes": [
     "/startEvent/06bc4aa2-a00a-4532-80c9-a4b5fe4499ae",
     "/requestTask/f3f35f6b-42fb-4fe6-aab6-b35abba5a8a2",
+    "/scriptTask/0cf53af7-c545-4632-9eff-f799f572afe6",
     "/fileTask/f7b1f4cf-4d39-478a-b77a-75dbc58f263b",
     "/scriptTask/60aa763e-d71c-4557-89d7-45592fbf8313",
     "/databaseConnectionTask/8b3f6942-c10f-4fdf-bc7f-e2afcdfc26e4",

--- a/create-tags/nodes/createTag.json
+++ b/create-tags/nodes/createTag.json
@@ -4,7 +4,7 @@
   "description": "create tag",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/tags",
+    "url": "{{{okapi-url}}}/tags",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",

--- a/create-tags/nodes/folioLogin.json
+++ b/create-tags/nodes/folioLogin.json
@@ -1,10 +1,10 @@
 {
   "id": "0abf1dbc-5da6-40f8-9f04-07cc52d5a5bc",
-  "name": "Login",
-  "description": "Get Login Token for Create Tags",
+  "name": "FOLIO Login",
+  "description": "Log into FOLIO, obtaining the appropriate tokens.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi}}}/authn/login",
+    "url": "{{{okapi-url}}}/authn/login-with-expiry",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",
@@ -22,13 +22,14 @@
   ],
   "headerOutputVariables": [
     {
-      "key": "X-Okapi-Token",
-      "type": "PROCESS"
+      "key": "Set-Cookie",
+      "type": "LOCAL",
+      "asArray": true
     }
   ],
   "outputVariable": {
     "key": "loginResponse",
-    "type": "PROCESS"
+    "type": "LOCAL"
   },
   "asyncBefore": true
 }

--- a/create-tags/nodes/getAccessToken.json
+++ b/create-tags/nodes/getAccessToken.json
@@ -1,0 +1,8 @@
+{
+  "id": "1d3ec96f-da08-4577-acff-891ab1a226db",
+  "name": "Get Access Token",
+  "description": "Get the FOLIO Access Token as an X-Okapi-Token.",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "getAccessToken.js"
+}

--- a/create-tags/nodes/js/getAccessToken.js
+++ b/create-tags/nodes/js/getAccessToken.js
@@ -1,0 +1,25 @@
+const TokenUtility = Java.type('org.folio.rest.camunda.utility.TokenUtility');
+
+/**
+ * Get the named headers, if defined.
+ *
+ * This requires that the `asArray` for the `headerOutputVariables` variable to be set to TRUE.
+ *
+ * Note: The scripts have access to all variables available and so do not specifically require the "inputVariables" to be defined.
+ *
+ * @param {string} name - The headers name to fetch.
+ *
+ * @return {string} The value of the named headers, or undefined.
+ */
+function getHeaders(name) {
+  if (execution.hasVariable(name)) {
+    return execution.getVariableTyped(name, true).getValue();
+  }
+}
+
+(function () {
+  const setCookie = getHeaders("Set-Cookie");
+  const accessToken = TokenUtility.getAccessTokens(setCookie);
+
+  execution.setVariable('X-Okapi-Token', accessToken);
+}());

--- a/create-tags/workflow.json
+++ b/create-tags/workflow.json
@@ -15,6 +15,7 @@
     "/fileTask/bc912058-7b71-4b50-8bf9-751d37a133cb",
     "/scriptTask/f52b03c9-c886-47b5-a377-4bb3b7d72f3b",
     "/requestTask/0abf1dbc-5da6-40f8-9f04-07cc52d5a5bc",
+    "/scriptTask/1d3ec96f-da08-4577-acff-891ab1a226db",
     "/subprocess/3a50b86e-e20c-4c12-8183-88844785df8b",
     "/fileTask/4d37e26e-5e83-445c-95e7-0c95a63ccf67",
     "/endEvent/1fdf4eea-c393-4f9b-b900-d79f70e3aa34"

--- a/hegis-po/nodes/js/buildQuery.js
+++ b/hegis-po/nodes/js/buildQuery.js
@@ -1,6 +1,5 @@
 if (logLevel === 'DEBUG') {
   print('\nlogLevel = ' + logLevel);
-  print('\nokapiUrl = ' + okapiUrl);
   print('\nusername = ' + username);
   print('\nemailTo = ' + emailTo);
   print('\nhegisCodes = ' + hegisCodes);

--- a/nbs-items-note/nodes/folioLogin.json
+++ b/nbs-items-note/nodes/folioLogin.json
@@ -1,10 +1,10 @@
 {
   "id": "a94cd209-e301-4f48-b8fa-c53e766279c9",
-  "name": "Okapi Login",
-  "description": "Login to Okapi.",
+  "name": "FOLIO Login",
+  "description": "Log into FOLIO, obtaining the appropriate tokens.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/authn/login",
+    "url": "{{{okapi-url}}}/authn/login-with-expiry",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",
@@ -22,13 +22,14 @@
   ],
   "headerOutputVariables": [
     {
-      "key": "X-Okapi-Token",
-      "type": "PROCESS"
+      "key": "Set-Cookie",
+      "type": "LOCAL",
+      "asArray": true
     }
   ],
   "outputVariable": {
     "key": "loginResponse",
-    "type": "PROCESS"
+    "type": "LOCAL"
   },
   "asyncBefore": true
 }

--- a/nbs-items-note/nodes/getAccessToken.json
+++ b/nbs-items-note/nodes/getAccessToken.json
@@ -1,0 +1,8 @@
+{
+  "id": "3b476f32-c359-46c1-88e2-e1409eb94f98",
+  "name": "Get Access Token",
+  "description": "Get the FOLIO Access Token as an X-Okapi-Token.",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "getAccessToken.js"
+}

--- a/nbs-items-note/nodes/getItem.json
+++ b/nbs-items-note/nodes/getItem.json
@@ -4,7 +4,7 @@
   "description": "Request the Item by its given Item ID.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/items/${item.id}",
+    "url": "{{{okapi-url}}}/inventory/items/${item.id}",
     "method": "GET",
     "accept": "application/json"
   },

--- a/nbs-items-note/nodes/js/getAccessToken.js
+++ b/nbs-items-note/nodes/js/getAccessToken.js
@@ -1,0 +1,25 @@
+const TokenUtility = Java.type('org.folio.rest.camunda.utility.TokenUtility');
+
+/**
+ * Get the named headers, if defined.
+ *
+ * This requires that the `asArray` for the `headerOutputVariables` variable to be set to TRUE.
+ *
+ * Note: The scripts have access to all variables available and so do not specifically require the "inputVariables" to be defined.
+ *
+ * @param {string} name - The headers name to fetch.
+ *
+ * @return {string} The value of the named headers, or undefined.
+ */
+function getHeaders(name) {
+  if (execution.hasVariable(name)) {
+    return execution.getVariableTyped(name, true).getValue();
+  }
+}
+
+(function () {
+  const setCookie = getHeaders("Set-Cookie");
+  const accessToken = TokenUtility.getAccessTokens(setCookie);
+
+  execution.setVariable('X-Okapi-Token', accessToken);
+}());

--- a/nbs-items-note/nodes/updateItem.json
+++ b/nbs-items-note/nodes/updateItem.json
@@ -4,7 +4,7 @@
   "description": "Update the Item using the appropriate REST request.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/items/${itemId}",
+    "url": "{{{okapi-url}}}/inventory/items/${itemId}",
     "method": "PUT",
     "contentType": "application/json",
     "accept": "text/plain",

--- a/nbs-items-note/workflow.json
+++ b/nbs-items-note/workflow.json
@@ -13,6 +13,7 @@
   "nodes": [
     "/startEvent/cdd600ba-e209-429c-a60f-f42632bfe5c3",
     "/requestTask/a94cd209-e301-4f48-b8fa-c53e766279c9",
+    "/scriptTask/3b476f32-c359-46c1-88e2-e1409eb94f98",
     "/databaseConnectionTask/7f7b1d38-a006-4dca-a9b2-d2fbb17c5dda",
     "/databaseQueryTask/badb402c-916d-4e0d-a525-fcaa8f490974",
     "/scriptTask/0df78f23-252f-448c-8bf0-0145cb22a728",

--- a/patron/nodes/folioLogin.json
+++ b/patron/nodes/folioLogin.json
@@ -1,10 +1,10 @@
 {
   "id": "b4996879-e2d8-41b7-89c0-46e762d93af8",
-  "name": "Login",
-  "description": "Login for token",
+  "name": "FOLIO Login",
+  "description": "Log into FOLIO, obtaining the appropriate tokens.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/authn/login",
+    "url": "{{{okapi-url}}}/authn/login-with-expiry",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",
@@ -13,13 +13,14 @@
   "inputVariables": [],
   "headerOutputVariables": [
     {
-      "key": "X-Okapi-Token",
-      "type": "PROCESS"
+      "key": "Set-Cookie",
+      "type": "LOCAL",
+      "asArray": true
     }
   ],
   "outputVariable": {
     "key": "loginResponse",
-    "type": "PROCESS"
+    "type": "LOCAL"
   },
   "asyncBefore": true
 }

--- a/patron/nodes/getAccessToken.json
+++ b/patron/nodes/getAccessToken.json
@@ -1,0 +1,8 @@
+{
+  "id": "4e609b08-34b1-4318-a28f-face82791bb8",
+  "name": "Get Access Token",
+  "description": "Get the FOLIO Access Token as an X-Okapi-Token.",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "getAccessToken.js"
+}

--- a/patron/nodes/import.json
+++ b/patron/nodes/import.json
@@ -4,7 +4,7 @@
   "description": "Request to post user collection to import",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/user-import",
+    "url": "{{{okapi-url}}}/user-import",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",

--- a/patron/nodes/js/getAccessToken.js
+++ b/patron/nodes/js/getAccessToken.js
@@ -1,0 +1,25 @@
+const TokenUtility = Java.type('org.folio.rest.camunda.utility.TokenUtility');
+
+/**
+ * Get the named headers, if defined.
+ *
+ * This requires that the `asArray` for the `headerOutputVariables` variable to be set to TRUE.
+ *
+ * Note: The scripts have access to all variables available and so do not specifically require the "inputVariables" to be defined.
+ *
+ * @param {string} name - The headers name to fetch.
+ *
+ * @return {string} The value of the named headers, or undefined.
+ */
+function getHeaders(name) {
+  if (execution.hasVariable(name)) {
+    return execution.getVariableTyped(name, true).getValue();
+  }
+}
+
+(function () {
+  const setCookie = getHeaders("Set-Cookie");
+  const accessToken = TokenUtility.getAccessTokens(setCookie);
+
+  execution.setVariable('X-Okapi-Token', accessToken);
+}());

--- a/patron/workflow.json
+++ b/patron/workflow.json
@@ -13,6 +13,7 @@
   "nodes": [
     "/startEvent/df9cff30-665a-11eb-b9fd-afcd4d476de5",
     "/requestTask/b4996879-e2d8-41b7-89c0-46e762d93af8",
+    "/scriptTask/4e609b08-34b1-4318-a28f-face82791bb8",
     "/databaseConnectionTask/55f9f79f-5ac4-4ec9-ba64-e596dae956b6",
     "/parallelGateway/36942c89-e5f6-49ad-8b61-a1ed9c53fcb5",
     "/moveToNode/76bff6c3-20be-4645-b7c6-8865ccd25603",

--- a/purchase-orders/nodes/acquisitionMethods.json
+++ b/purchase-orders/nodes/acquisitionMethods.json
@@ -4,7 +4,7 @@
   "description": "Retrieve the acquisition methods.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/orders/acquisition-methods?limit=999",
+    "url": "{{{okapi-url}}}/orders/acquisition-methods?limit=999",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/createCompositePurchaseOrder.json
+++ b/purchase-orders/nodes/createCompositePurchaseOrder.json
@@ -4,7 +4,7 @@
   "description": "Requests creation of a composite purchase order by posting data to the request url.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/orders/composite-orders",
+    "url": "{{{okapi-url}}}/orders/composite-orders",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",

--- a/purchase-orders/nodes/createNote.json
+++ b/purchase-orders/nodes/createNote.json
@@ -4,7 +4,7 @@
   "description": "Creates a purchase order line note using POST request.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/notes",
+    "url": "{{{okapi-url}}}/notes",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",

--- a/purchase-orders/nodes/createSnapshot.json
+++ b/purchase-orders/nodes/createSnapshot.json
@@ -4,7 +4,7 @@
   "description": "Submits job execution to create storage snapshot using POST request.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/source-storage/snapshots",
+    "url": "{{{okapi-url}}}/source-storage/snapshots",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",

--- a/purchase-orders/nodes/createSourceRecord.json
+++ b/purchase-orders/nodes/createSourceRecord.json
@@ -4,7 +4,7 @@
   "description": "Create source record",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/source-storage/records",
+    "url": "{{{okapi-url}}}/source-storage/records",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",

--- a/purchase-orders/nodes/folioLogin.json
+++ b/purchase-orders/nodes/folioLogin.json
@@ -1,10 +1,10 @@
 {
   "id": "179d06af-72a2-408a-a2fd-bf45300d55a8",
-  "name": "Login",
-  "description": "Gets OKAPI login token for purchase orders.",
+  "name": "FOLIO Login",
+  "description": "Log into FOLIO, obtaining the appropriate tokens.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/authn/login",
+    "url": "{{{okapi-url}}}/authn/login-with-expiry",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",
@@ -22,13 +22,14 @@
   ],
   "headerOutputVariables": [
     {
-      "key": "X-Okapi-Token",
-      "type": "PROCESS"
+      "key": "Set-Cookie",
+      "type": "LOCAL",
+      "asArray": true
     }
   ],
   "outputVariable": {
     "key": "loginResponse",
-    "type": "PROCESS"
+    "type": "LOCAL"
   },
   "asyncBefore": true
 }

--- a/purchase-orders/nodes/getAccessToken.json
+++ b/purchase-orders/nodes/getAccessToken.json
@@ -1,0 +1,8 @@
+{
+  "id": "61a2062b-d760-4570-855e-c7ece56bfd3a",
+  "name": "Get Access Token",
+  "description": "Get the FOLIO Access Token as an X-Okapi-Token.",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "getAccessToken.js"
+}

--- a/purchase-orders/nodes/getHoldingsOfInstance.json
+++ b/purchase-orders/nodes/getHoldingsOfInstance.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the holdings associated with the instance created by the purchase order line.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/holdings-storage/holdings?query=(instanceId==\"${instanceId}\")",
+    "url": "{{{okapi-url}}}/holdings-storage/holdings?query=(instanceId==\"${instanceId}\")",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/getInstanceOfPoLine.json
+++ b/purchase-orders/nodes/getInstanceOfPoLine.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the instance created by the purchase order line.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/instances/${instanceId}",
+    "url": "{{{okapi-url}}}/inventory/instances/${instanceId}",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/getItemsOfHoldings.json
+++ b/purchase-orders/nodes/getItemsOfHoldings.json
@@ -4,7 +4,7 @@
   "description": "Retrieve the items of instance holdings by the purchase order line.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/item-storage/items?query=(holdingsRecordId==\"${holdingsRecordId}\")",
+    "url": "{{{okapi-url}}}/item-storage/items?query=(holdingsRecordId==\"${holdingsRecordId}\")",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/getPurchaseOrderNumber.json
+++ b/purchase-orders/nodes/getPurchaseOrderNumber.json
@@ -4,7 +4,7 @@
   "description": "Requests the next purchase order.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/orders/po-number",
+    "url": "{{{okapi-url}}}/orders/po-number",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/holdingsTypes.json
+++ b/purchase-orders/nodes/holdingsTypes.json
@@ -4,7 +4,7 @@
   "description": "Retrieves holdings types from the specified url.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/holdings-types?limit=999",
+    "url": "{{{okapi-url}}}/holdings-types?limit=999",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/instanceTypes.json
+++ b/purchase-orders/nodes/instanceTypes.json
@@ -4,7 +4,7 @@
   "description": "Retrieves instance types from the specified url.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/instance-types?limit=999",
+    "url": "{{{okapi-url}}}/instance-types?limit=999",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/js/getAccessToken.js
+++ b/purchase-orders/nodes/js/getAccessToken.js
@@ -1,0 +1,25 @@
+const TokenUtility = Java.type('org.folio.rest.camunda.utility.TokenUtility');
+
+/**
+ * Get the named headers, if defined.
+ *
+ * This requires that the `asArray` for the `headerOutputVariables` variable to be set to TRUE.
+ *
+ * Note: The scripts have access to all variables available and so do not specifically require the "inputVariables" to be defined.
+ *
+ * @param {string} name - The headers name to fetch.
+ *
+ * @return {string} The value of the named headers, or undefined.
+ */
+function getHeaders(name) {
+  if (execution.hasVariable(name)) {
+    return execution.getVariableTyped(name, true).getValue();
+  }
+}
+
+(function () {
+  const setCookie = getHeaders("Set-Cookie");
+  const accessToken = TokenUtility.getAccessTokens(setCookie);
+
+  execution.setVariable('X-Okapi-Token', accessToken);
+}());

--- a/purchase-orders/nodes/loanTypes.json
+++ b/purchase-orders/nodes/loanTypes.json
@@ -4,7 +4,7 @@
   "description": "Retrieves loan types from the specified url.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/loan-types?limit=999",
+    "url": "{{{okapi-url}}}/loan-types?limit=999",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/locations.json
+++ b/purchase-orders/nodes/locations.json
@@ -4,7 +4,7 @@
   "description": "Requests locations from the endpoint",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/locations?limit=999",
+    "url": "{{{okapi-url}}}/locations?limit=999",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/lookupConfigurationEntryByValue.json
+++ b/purchase-orders/nodes/lookupConfigurationEntryByValue.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the configuration entry by value name.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/configurations/entries?query=(value==\"*\\\"name\\\":\\\"${marcOrderData.billTo}\\\"*\")",
+    "url": "{{{okapi-url}}}/configurations/entries?query=(value==\"*\\\"name\\\":\\\"${marcOrderData.billTo}\\\"*\")",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/lookupExpenseClassByName.json
+++ b/purchase-orders/nodes/lookupExpenseClassByName.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the expense class by name.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/finance/expense-classes?limit=1&offset=0&query=(name==\"${marcOrderData.expenseClass}\")",
+    "url": "{{{okapi-url}}}/finance/expense-classes?limit=1&offset=0&query=(name==\"${marcOrderData.expenseClass}\")",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/lookupFundByCode.json
+++ b/purchase-orders/nodes/lookupFundByCode.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the fund by code.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/finance/funds?limit=1&offset=0&query=(code==\"${marcOrderData.fundCode}\")",
+    "url": "{{{okapi-url}}}/finance/funds?limit=1&offset=0&query=(code==\"${marcOrderData.fundCode}\")",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/lookupStatisticalCodeByCode.json
+++ b/purchase-orders/nodes/lookupStatisticalCodeByCode.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the statistical code by code.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/statistical-codes?limit=99&query=(code==\"${statisticalCode}\")",
+    "url": "{{{okapi-url}}}/statistical-codes?limit=99&query=(code==\"${statisticalCode}\")",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/lookupVendorByCode.json
+++ b/purchase-orders/nodes/lookupVendorByCode.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the vendor details by code.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/organizations-storage/organizations?limit=1&offset=0&query=((code='${marcOrderData.vendorCode}'))",
+    "url": "{{{okapi-url}}}/organizations-storage/organizations?limit=1&offset=0&query=((code='${marcOrderData.vendorCode}'))",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/materialTypes.json
+++ b/purchase-orders/nodes/materialTypes.json
@@ -4,7 +4,7 @@
   "description": "Retrieve the Material Types.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/material-types?limit=999",
+    "url": "{{{okapi-url}}}/material-types?limit=999",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/noteTypes.json
+++ b/purchase-orders/nodes/noteTypes.json
@@ -4,7 +4,7 @@
   "description": "Retrieves the note types.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/note-types?limit=999",
+    "url": "{{{okapi-url}}}/note-types?limit=999",
     "method": "GET",
     "accept": "application/json"
   },

--- a/purchase-orders/nodes/updateHoldings.json
+++ b/purchase-orders/nodes/updateHoldings.json
@@ -4,7 +4,7 @@
   "description": "Request task to update holdings.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/holdings-storage/holdings/${holdingsRecordId}",
+    "url": "{{{okapi-url}}}/holdings-storage/holdings/${holdingsRecordId}",
     "method": "PUT",
     "contentType": "application/json",
     "accept": "text/plain",

--- a/purchase-orders/nodes/updateInstance.json
+++ b/purchase-orders/nodes/updateInstance.json
@@ -4,7 +4,7 @@
   "description": "Request task to update instance mapped from MARC record.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/instances/${instanceId}",
+    "url": "{{{okapi-url}}}/inventory/instances/${instanceId}",
     "method": "PUT",
     "contentType": "application/json",
     "accept": "application/json",

--- a/purchase-orders/nodes/updateItem.json
+++ b/purchase-orders/nodes/updateItem.json
@@ -4,7 +4,7 @@
   "description": "Request task to update an item.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/item-storage/items/${itemId}",
+    "url": "{{{okapi-url}}}/item-storage/items/${itemId}",
     "method": "PUT",
     "contentType": "application/json",
     "accept": "text/plain",

--- a/purchase-orders/workflow.json
+++ b/purchase-orders/workflow.json
@@ -13,6 +13,7 @@
   "nodes": [
     "/startEvent/9219c68d-8019-4b3d-9ea6-f1a3a1c2d22c",
     "/requestTask/179d06af-72a2-408a-a2fd-bf45300d55a8",
+    "/scriptTask/61a2062b-d760-4570-855e-c7ece56bfd3a",
     "/parallelGateway/b4440bc5-6fe8-4bf3-aa41-57debe0a813f",
     "/moveToNode/6237b530-fa88-4b41-ac82-23c2c9069ab2",
     "/moveToNode/3bafb8b3-f358-4218-9d30-9843e7970e90",

--- a/remove-books-from-nbs/nodes/folioLogin.json
+++ b/remove-books-from-nbs/nodes/folioLogin.json
@@ -1,10 +1,10 @@
 {
   "id": "00f3edaf-bc3e-4bf5-bdbc-2de6c6d7f972",
-  "name": "Login",
-  "description": "Get Login Token",
+  "name": "FOLIO Login",
+  "description": "Log into FOLIO, obtaining the appropriate tokens.",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi}}}/authn/login",
+    "url": "{{{okapi-url}}}/authn/login-with-expiry",
     "method": "POST",
     "contentType": "application/json",
     "accept": "application/json",
@@ -22,13 +22,14 @@
   ],
   "headerOutputVariables": [
     {
-      "key": "X-Okapi-Token",
-      "type": "PROCESS"
+      "key": "Set-Cookie",
+      "type": "LOCAL",
+      "asArray": true
     }
   ],
   "outputVariable": {
     "key": "loginResponse",
-    "type": "PROCESS"
+    "type": "LOCAL"
   },
   "asyncBefore": true
 }

--- a/remove-books-from-nbs/nodes/getAccessToken.json
+++ b/remove-books-from-nbs/nodes/getAccessToken.json
@@ -1,0 +1,8 @@
+{
+  "id": "b4fdb3a5-c1e4-461d-bfa7-3b9912c09265",
+  "name": "Get Access Token",
+  "description": "Get the FOLIO Access Token as an X-Okapi-Token.",
+  "deserializeAs": "ScriptTask",
+  "scriptFormat": "javascript",
+  "code": "getAccessToken.js"
+}

--- a/remove-books-from-nbs/nodes/itemLookupRequest.json
+++ b/remove-books-from-nbs/nodes/itemLookupRequest.json
@@ -4,7 +4,7 @@
   "description": "",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/items?query=barcode==${barcode}",
+    "url": "{{{okapi-url}}}/inventory/items?query=barcode==${barcode}",
     "method": "GET",
     "accept": "application/json"
   },

--- a/remove-books-from-nbs/nodes/itemUpdateRequest.json
+++ b/remove-books-from-nbs/nodes/itemUpdateRequest.json
@@ -4,7 +4,7 @@
   "description": "",
   "deserializeAs": "RequestTask",
   "request": {
-    "url": "{{{okapi-internal}}}/inventory/items/${item.prop('id').stringValue()}",
+    "url": "{{{okapi-url}}}/inventory/items/${item.prop('id').stringValue()}",
     "method": "PUT",
     "contentType": "application/json",
     "accept": "application/json",

--- a/remove-books-from-nbs/nodes/js/getAccessToken.js
+++ b/remove-books-from-nbs/nodes/js/getAccessToken.js
@@ -1,0 +1,25 @@
+const TokenUtility = Java.type('org.folio.rest.camunda.utility.TokenUtility');
+
+/**
+ * Get the named headers, if defined.
+ *
+ * This requires that the `asArray` for the `headerOutputVariables` variable to be set to TRUE.
+ *
+ * Note: The scripts have access to all variables available and so do not specifically require the "inputVariables" to be defined.
+ *
+ * @param {string} name - The headers name to fetch.
+ *
+ * @return {string} The value of the named headers, or undefined.
+ */
+function getHeaders(name) {
+  if (execution.hasVariable(name)) {
+    return execution.getVariableTyped(name, true).getValue();
+  }
+}
+
+(function () {
+  const setCookie = getHeaders("Set-Cookie");
+  const accessToken = TokenUtility.getAccessTokens(setCookie);
+
+  execution.setVariable('X-Okapi-Token', accessToken);
+}());

--- a/remove-books-from-nbs/workflow.json
+++ b/remove-books-from-nbs/workflow.json
@@ -15,6 +15,7 @@
     "/fileTask/7e95d7c3-6a22-4708-8294-ce3a46aa33f5",
     "/scriptTask/0a72dc6a-cffa-4a70-9257-5c4bc1ef9ea9",
     "/requestTask/00f3edaf-bc3e-4bf5-bdbc-2de6c6d7f972",
+    "/scriptTask/b4fdb3a5-c1e4-461d-bfa7-3b9912c09265",
     "/subprocess/d7c46475-9194-4c6d-8703-772a8e57cba3",
     "/subprocess/db5cd3d2-a3f8-4e5e-830b-e0e3f23d5fa9",
     "/scriptTask/02cdf90c-8ca4-4aef-8bb5-a9c0242a9fd6",


### PR DESCRIPTION
Part of #464.
Resolves #472.

Refactor `okapi-internal` to `okapi-url` to be more clear and consistent.
There is documentation regarding `okapiUrl` but its only use is a console log in `hegis-po`.
Remove both the reference to the `okapiUrl` and the console log in `hegis-po`.

Rename all Okapi Login JSON files to `folioLogin.json` to make things consistent.
Update descriptions and names.

Switch the `X-Okapi-Token` `headerOutputVariables` processing to `Set-Cookie` with the `asArray` set to `true`.
This is now a `LOCAL` varaible because it should not be exposed to the top-level of the process.
The  `loginResponse` should also be `LOCAL` for the same reasons.

The **Get Access Token** is a direct copy of the logic from the **Example FOLIO Login** workflow.

Note: This needs testing in our local DEV environment. This paragraph will be remove once the tested is complete and things are confirmed to be working.