### PR TITLE
Spring Boot 4 related changes.

### DIFF
--- a/purchase-orders/nodes/js/prepareInstance.js
+++ b/purchase-orders/nodes/js/prepareInstance.js
@@ -23,7 +23,7 @@ var mapStatisticalCodeIds = function (statisticalCodes) {
   return statisticalCodeIds;
 };
 
-var mappedInstance = MappingUtility.mapRecordToInsance(marcJsonRecord, okapiUrl, tenant, token);
+var mappedInstance = MappingUtility.mapRecordToInstance(marcJsonRecord, okapiUrl, tenant, token);
 var mappedInstanceObj = JSON.parse(mappedInstance);
 
 mappedInstanceObj.id = instanceObj.id;


### PR DESCRIPTION
Rename mapRecordToInsance() to mapRecordToInstance().
  - The function name spelling mistake was corrected during the Spring-Boot 4 upgrade process in mod-camunda.