### PR TITLE
Issue 501: Remove duplicate `tenantId` key.

### DIFF
--- a/orcid/nodes/fastQuery.json
+++ b/orcid/nodes/fastQuery.json
@@ -11,10 +11,6 @@
     {
       "key": "tenantId",
       "type": "PROCESS"
-    },
-    {
-      "key": "tenantId",
-      "type": "PROCESS"
     }
   ],
   "outputVariable": {},


### PR DESCRIPTION
Resolves #501 .

The `orcid` workflow builds under **Spring Boot 4.1** once the duplicate `tenantId` key is removed.